### PR TITLE
Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,12 @@ RUN apt-get update && \
 # Install Miniconda and add to PATH
 RUN curl https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O && \
     bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bf -p /usr/miniconda3/ && \
-    rm Miniconda3-4.7.12.1-Linux-x86_64.sh
+    rm Miniconda3-4.7.12.1-Linux-x86_64.sh && \
+    /usr/miniconda3/bin/conda clean -tipsy && \
+    ln -s /usr/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /usr/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
+
 
 # Add conda to PATH and set locale
 ENV PATH="/usr/miniconda3/bin:${PATH}"

--- a/docker/Dockerfile_slim
+++ b/docker/Dockerfile_slim
@@ -24,7 +24,11 @@ RUN apt-get update && \
 # Install Miniconda and add to PATH
 RUN curl https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O && \
     bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bf -p /usr/miniconda3/ && \
-    rm Miniconda3-4.7.12.1-Linux-x86_64.sh
+    rm Miniconda3-4.7.12.1-Linux-x86_64.sh && \
+    /usr/miniconda3/bin/conda clean -tipsy && \
+    ln -s /usr/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /usr/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
 
 # Add conda to PATH and set locale
 ENV PATH="/usr/miniconda3/bin:${PATH}"

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -24,7 +24,11 @@ RUN apt-get update && \
 # Install Miniconda and add to PATH
 RUN curl https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O && \
     bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bf -p /usr/miniconda3/ && \
-    rm Miniconda3-4.7.12.1-Linux-x86_64.sh
+    rm Miniconda3-4.7.12.1-Linux-x86_64.sh && \
+    /usr/miniconda3/bin/conda clean -tipsy && \
+    ln -s /usr/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /usr/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
 
 # Add conda to PATH and set locale
 ENV PATH="/usr/miniconda3/bin:${PATH}"

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
                                                language-pack-en \
                                                tzdata \
                                                vim \
+                                               unzip \
                                                wget \
     && apt-get clean
 


### PR DESCRIPTION
This PR updates the Dockerfiles so that conda becomes integrated in the image. This also ensures that `conda activate` works for those who run tutorials via the `slim` Docker tag.