### PR TITLE
Remove legacy link and fix formatting

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -14,9 +14,6 @@ on how to make your data analyses reproducible. In particular, it covers:
 
 <h1> Material </h1>
 
-Slides from lectures covering the topics above are available on [Google
-Drive](https://drive.google.com/open?id=1yR9ti8nAbAfPGf9-COVWKSGISpUW8Wmm)
-
 This documentation and all the resources used in the course are available as a
 [GitHub repo](https://github.com/NBISweden/workshop-reproducible-research.git).
 

--- a/docs/travel.md
+++ b/docs/travel.md
@@ -5,12 +5,12 @@ Links to the zoom meeting and for the HackMD used during the course are sent out
 
 # Finding the course venue
 
-N.A.
+--
 
 # Finding the restaurant for the course dinner
 
-N.A.
+--
 
 # Finding the "social event" venue
 
-N.A.
+--


### PR DESCRIPTION
Not sure if we want to keep the link to the Google Drive lectures from last year, here is a version where it is removed.