### PR TITLE
Day 4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,8 +62,4 @@ RUN echo -e "library(tinytex)\ntinytex::install_tinytex(dir='/usr/.TinyTeX')"| R
 # (Jupyter Notebook has to be separately installed in the container)
 EXPOSE 8888
 
-# Add conda envs dir
-ENV CONDA_ENVS_PATH="/course/envs"
-RUN mkdir /course/envs
-
 CMD snakemake -rp --configfile config.yml

--- a/docker/Dockerfile_slim
+++ b/docker/Dockerfile_slim
@@ -36,8 +36,6 @@ RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64
 ENV PATH="/usr/miniconda3/bin:${PATH}"
 ENV LC_ALL en_US.UTF-8
 ENV LC_LANG en_US.UTF-8
-ENV CONDA_ENVS_PATH="/course/envs"
-RUN mkdir /course/envs
 
 # Open port for running Jupyter Notebook
 EXPOSE 8888

--- a/docker/code/supplementary_material.Rmd
+++ b/docker/code/supplementary_material.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Supplementary Material"
-output: pdf_document
+output: html_document
 params:
   counts_file: "results/tables/counts.tsv"
   multiqc_file: "intermediate/multiqc_general_stats.txt"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -453,24 +453,12 @@ automatically activates the Conda base environment in the container.
 ENV PATH="/usr/miniconda3/bin:${PATH}"
 ENV LC_ALL en_US.UTF-8
 ENV LC_LANG en_US.UTF-8
-ENV CONDA_ENVS_PATH="/course/envs"
-RUN mkdir /course/envs
 ```
 
 Here we use the new instruction `ENV`. The first command adds `conda` to the
 path, so we can write `conda install` instead of `/usr/miniconda3/bin/conda install`. 
 The next two commands set an UTF-8 character encoding so that we can use
-weird characters (and a bunch of other things). The final two commands
-are specifying a directory in which Conda environments are stored.
-Every time an image is run, a brand new container is started and Conda 
-environments from previous runs that were stored in the default directory would be lost. 
-The directory `course/` can be mounted to a local directory when starting
-the container. This will make it and all its contents that are created while running
-the container available on the local computer (more about bind mounts further 
-below in the tutorial). So by specifying this directory in the Dockerfile, 
-Conda environments from previous runs of the image can be made available
-in future runs.
-
+weird characters (and a bunch of other things). 
 
 ```no-highlight
 # Open port for running Jupyter Notebook

--- a/docs/singularity.md
+++ b/docs/singularity.md
@@ -434,15 +434,17 @@ Since Singularity bind mounts the current working directory we can simply
 execute the workflow and generate the output files using:
 
 ```bash
-singularity run mrsa_proj.sif
+singularity run --vm-ram 2048 mrsa_proj.sif
 ```
 
 This executes the default run command, which is `snakemake -rp --configfile 
 config.yml` (as defined in the original `Dockerfile`). 
 
-The previous step in this tutorial included running the `run_qc.sh` script, so 
-that part of the workflow has already been run and Snakemake will continue from 
-that automatically without redoing anything. Once completed you should see a bunch
+Note here that we have also increased the allocated RAM to 2048 MiB (`--vm
+-ram 2048`), needed to fully run through the workflow. The previous step in
+this tutorial included running the `run_qc.sh` script, so that part of the
+workflow has already been run and Snakemake will continue from that 
+automatically without redoing anything. Once completed you should see a bunch
 of directories and files generated in your current working directory, including 
 the `results/` directory containing the 
 final HTML report.

--- a/docs/tutorial_intro.md
+++ b/docs/tutorial_intro.md
@@ -191,6 +191,44 @@ git clone https://github.com/NBISweden/workshop-reproducible-research.git
 cd workshop-reproducible-research
 ```
 
+#### Setting up persistent conda environments
+Because the root file system of each container is an isolated instance conda
+environments you create during this course will be lost if you exit the 
+container or if it is killed for some reason. This means that you will have to 
+recreate each environment every time you run a new container for
+the course. To avoid this, you can make sure conda uses a subfolder `envs/` 
+inside the `/course` directory for storing environments. If you run containers
+for the course with some folder on your local machine mounted inside `/course`
+that will cause the conda environments to be available on your local machine
+even though they are created inside the container. Should a container be stopped
+for some reason you can simply run a new one and activate conda environments
+under `/course/envs`, saving you the trouble of recreating them.
+
+What you have to do is to, after you've started a container with the 
+`docker run` command above, first create the `envs/` directory:
+
+```bash
+mkdir /course/envs
+``` 
+
+Then set the environment variable `CONDA_ENVS_PATH` to `/course/envs`:
+
+```bash
+export CONDA_ENVS_PATH="/course/envs"
+```
+
+Now when you use Conda to create environments inside the Docker container for
+the course, the environments will be placed in `/course/envs` which is also 
+present on your local system because you mounted the folder inside the 
+container. **Note that you will have to set the `CONDA_ENVS_PATH` each time you
+start a new container for this to work**.
+
+!!! attention
+    This usage of persistent conda environments should be considered an edge 
+    case of how you use Docker containers. We do this only to make it easier to
+    run the course through Docker, but in general we do not advocate creating
+    conda environments separate from the actual Docker container.  
+
 Don't worry if you feel that this Docker stuff is a little confusing, it will
 become clearer in the [Docker tutorial](docker.md). However, the priority right
 now is just to get it running so that you can start working.

--- a/docs/tutorial_intro.md
+++ b/docs/tutorial_intro.md
@@ -192,16 +192,16 @@ cd workshop-reproducible-research
 ```
 
 #### Setting up persistent conda environments
-Because the root file system of each container is an isolated instance conda
+Because the root file system of each container is an isolated instance, Conda
 environments you create during this course will be lost if you exit the 
 container or if it is killed for some reason. This means that you will have to 
 recreate each environment every time you run a new container for
-the course. To avoid this, you can make sure conda uses a subfolder `envs/` 
+the course. To avoid this, you can make sure that Conda uses a subfolder `envs/` 
 inside the `/course` directory for storing environments. If you run containers
 for the course with some folder on your local machine mounted inside `/course`
-that will cause the conda environments to be available on your local machine
+that will cause the Conda environments to be available on your local machine
 even though they are created inside the container. Should a container be stopped
-for some reason you can simply run a new one and activate conda environments
+for some reason you can simply run a new one and activate Conda environments
 under `/course/envs`, saving you the trouble of recreating them.
 
 What you have to do is to, after you've started a container with the 
@@ -224,10 +224,10 @@ container. **Note that you will have to set the `CONDA_ENVS_PATH` each time you
 start a new container for this to work**.
 
 !!! attention
-    This usage of persistent conda environments should be considered an edge 
+    This usage of persistent Conda environments should be considered an edge 
     case of how you use Docker containers. We do this only to make it easier to
     run the course through Docker, but in general we do not advocate creating
-    conda environments separate from the actual Docker container.  
+    Conda environments separate from the actual Docker container.  
 
 Don't worry if you feel that this Docker stuff is a little confusing, it will
 become clearer in the [Docker tutorial](docker.md). However, the priority right


### PR DESCRIPTION
- Adds HackMD contents from day 4
- Remove setup of `/course/envs` persistent conda dir from Dockerfiles
- Clarify that using persistent conda envs dir is an edge case for the course