### PR TITLE
Use "WfMS" instead of "WMS"

### DIFF
--- a/pages/nextflow/nextflow-1-introduction.md
+++ b/pages/nextflow/nextflow-1-introduction.md
@@ -1,4 +1,4 @@
-[Nextflow](https://www.nextflow.io/) is a *workflow management system* (WMS),
+[Nextflow](https://www.nextflow.io/) is a *workflow management system* (WfMS),
 and is one of the most common such systems within the bioinformatic and
 academic communities. These systems are important for scientific
 reproducibility in that they greatly facilitate keeping track of which files

--- a/pages/nextflow/nextflow-3-executing-workflows.md
+++ b/pages/nextflow/nextflow-3-executing-workflows.md
@@ -69,7 +69,7 @@ picking which ones are important or interesting to you - or don’t include any!
 
 # Re-running workflows
 
-Something you often want to do in Nextflow (or any WMS for that matter) is to
+Something you often want to do in Nextflow (or any WfMS for that matter) is to
 re-run the workflow when you changed some input files or some of the code for
 its analyses, but you don't want to re-run the entire workflow from start to
 finish. Let’s find out how this works in Nextflow!
@@ -93,14 +93,14 @@ that only processes relevant to your changes are executed again!
 * Use `tree work` to list the contents of the work directory.
 
 Because Nextflow keeps track of all the runs, we've now got two sets of files
-in the work directory. One set from the first run, and another from the second run. This
-can take up valuable space, so let's clean that up.
+in the work directory. One set from the first run, and another from the second
+run. This can take up valuable space, so let's clean that up.
 
 * Use `nextflow clean -n -before <run_name>` to show which work directories
 will be cleaned up. Then delete those directories by changing `-n` to `-f`.
 
 Nextflow's `clean` subcommand can be used to clean up failed tasks and unused
-processes. Use `nextflow help clean` to see other options for cleaning. 
+processes. Use `nextflow help clean` to see other options for cleaning.
 This is the preferred way to clean up the working directory.
 
 * Remove the `results` directory and re-run the workflow again using the
@@ -110,7 +110,7 @@ We removed all the results we used before, but we still managed to resume the
 workflow and use its cache - how come? Remember that Nextflow uses the `work`
 directory to run all of its tasks, while the `results` directory is just where
 we have chosen to publish our outputs. We can thus delete the `results`
-directory as often as we like (a necessity when output filenames are changed) 
+directory as often as we like (a necessity when output filenames are changed)
 and still get everything back without having to re-run
 anything. If we were to delete the `work` directory, however...
 
@@ -152,7 +152,7 @@ run by looking into the `.nextflow.log` file!
 
 You'll be greeted by a wealth of debugging information, which may even seem a
 bit overkill at this point! This level of detail is, however, quite useful both
-as a history of what you've attempted and as an additional help when you run 
+as a history of what you've attempted and as an additional help when you run
 into errors! Also, it helps with advanced debugging - which we'll get into later.
 
 > **Quick recap** <br>

--- a/pages/snakemake/snakemake-1-introduction.md
+++ b/pages/snakemake/snakemake-1-introduction.md
@@ -1,6 +1,6 @@
-A *workflow management system* (WMS) is a piece of software that sets up,
+A *workflow management system* (WfMS) is a piece of software that sets up,
 performs and monitors a defined sequence of computational tasks (*i.e.* "a
-workflow"). Snakemake is a WMS that was developed in the bioinformatics
+workflow"). Snakemake is a WfMS that was developed in the bioinformatics
 community, and as such it has a number of features that make it particularly
 well-suited for creating reproducible and scalable data analyses.
 
@@ -23,7 +23,7 @@ files. It's also a good fit for a scientific research setting, where the exact
 specifications of the final workflow aren't always known at the beginning of
 a project.
 
-Lastly, a WMS is a very important tool for making your analyses reproducible.
+Lastly, a WfMS is a very important tool for making your analyses reproducible.
 By keeping track of when each file was generated, and by which operation, it is
 possible to ensure that there is a consistent "paper trail" from raw data to
 final results. Snakemake also has features that allow you to package and

--- a/pages/snakemake/snakemake-3-visualising-workflows.md
+++ b/pages/snakemake/snakemake-3-visualising-workflows.md
@@ -1,12 +1,12 @@
 All that we've done so far could quite easily be done in a simple shell script
 that takes the input files as parameters. Let's now take a look at some of the
-features where a WMS like Snakemake really adds value compared to a more
+features where a WfMS like Snakemake really adds value compared to a more
 straightforward approach. One such feature is the possibility to visualize your
 workflow. Snakemake can generate two types of graphs, one that shows how the
 rules are connected and one that shows how the jobs (*i.e.* an execution of
-a rule with some given inputs/outputs/settings) are connected. 
+a rule with some given inputs/outputs/settings) are connected.
 
-First we look at the rule graph. The following command will generate a rule graph 
+First we look at the rule graph. The following command will generate a rule graph
 in the dot language and pipe it to the program `dot`, which in turn will save
 a visualization of the graph as a PNG file (if you're having troubles displaying
 PNG files you could use SVG or JPG instead).
@@ -18,15 +18,15 @@ snakemake --rulegraph a_b.txt | dot -Tpng > rulegraph.png
 ![](images/rulegraph.svg)
 
 This looks simple enough, the output from the rule `convert_to_upper_case` will
-be used as input to the rule `concatenate_files`. 
+be used as input to the rule `concatenate_files`.
 
-For a more typical bioinformatics project it can look something like this when you 
+For a more typical bioinformatics project it can look something like this when you
 include all the rules from processing of the raw data to generating figures for the paper.
 
 ![](images/rulegraph_complex.svg)
 
 While saying that it's easy to read might be a bit of a stretch, it definitely
-gives you a better overview of the project than you would have without a WMS.
+gives you a better overview of the project than you would have without a WfMS.
 
 The second type of graph is based on the jobs, and looks like this for our
 little workflow (use `--dag` instead of `--rulegraph`).
@@ -45,7 +45,7 @@ way of indicating that this rule doesn't need to be rerun in order to generate
 that there is nothing to be done.
 
 
-We've discussed before that one of the main purposes of using a WMS is that it
+We've discussed before that one of the main purposes of using a WfMS is that it
 automatically makes sure that everything is up to date. This is done by
 recursively checking that outputs are always newer than inputs for all the
 rules involved in the generation of your target files. Now try to change the
@@ -100,8 +100,8 @@ This was a dry-run (flag -n). The order of jobs does not reflect the order of ex
 
 Were you correct? Also generate the job graph and compare to the one generated
 above. What's the difference? Now rerun without `-n` and validate that
-`a_b.txt` contains the new text (don't forget to specify `-c 1`). Note that 
-Snakemake doesn't look at the contents of files when trying to determine what has 
+`a_b.txt` contains the new text (don't forget to specify `-c 1`). Note that
+Snakemake doesn't look at the contents of files when trying to determine what has
 changed, only at the timestamp for when they were last modified.
 
 We've seen that Snakemake keeps track of if files in the workflow have changed,
@@ -222,11 +222,11 @@ snakemake a_b.txt --list-code-changes
 ```
 
 You should see the `a_b.txt` file printed to the terminal, meaning that Snakemake
-has identified changes to the implementation of the `concatenate_files` rule 
-which produces the `a_b.txt` file. Note that only changes to the `shell`, `run`, 
-`notebook` or `script` directives are tracked by `--list-code-changes`. 
+has identified changes to the implementation of the `concatenate_files` rule
+which produces the `a_b.txt` file. Note that only changes to the `shell`, `run`,
+`notebook` or `script` directives are tracked by `--list-code-changes`.
 
-We can then force Snakemake to regenerate the files that depend on the updated 
+We can then force Snakemake to regenerate the files that depend on the updated
 rules with the `-R` flag:
 
 ```bash


### PR DESCRIPTION
Use the "WfMS" abbreviation of Workflow Management System instead of WMS, as that is listed in several sources online, including Wikipedia and the Carpentries. I think that "WfMS" is a bit ugly, but it seems to be the most common abbreviation in my quick search, but it might be better to use it for consistency for our students looking at other material.