### PR TITLE
Add Gitpod yaml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,1 @@
+image: nfcore/gitpod:latest


### PR DESCRIPTION
Adds the nf-core docker container as a base image for Gitpod. 
The nf-core image is defined at https://github.com/nf-core/tools/blob/master/nf_core/gitpod/gitpod.Dockerfile

Notable tools available:
- Docker
- Conda
- Mamba
- Nextflow
( Singularity is not possible because of kernel limitations)

RStudio can be run through docker-compose if needed: see https://github.com/mahesh-panchal/reproducible-research/blob/main/docker-compose.yml
A Jupyter notebook could likely be run in the same way.