### PR TITLE
Conda2mamba

### DIFF
--- a/pages/conda/conda-1-introduction.md
+++ b/pages/conda/conda-1-introduction.md
@@ -1,11 +1,23 @@
 Conda is a package and environment manager. As a package manager it enables you
 to install a wide range of software and tools using one simple command: `conda
 install`. As an environment manager it allows you to create and manage multiple
-different environments, each with their own set of packages. What are the
-benefits of using an environment manager? Some examples include the ability to
-easily run different versions of the same package, have different cross-package
-dependencies that are otherwise incompatible with each other and, last but not
-least, easy installation of all the software needed for an analysis.
+different environments, each with their own set of packages. 
+
+> **Mamba vs Conda**
+> As explained in the [pre-course-setup](pre-course-setup) we advocate 
+> using Mamba instead of Conda. Mamba is a faster reimplementation of Conda and
+> can often solve environments where Conda fails to do the job. On the 
+> command line `mamba` works as a drop-in replacement for `conda`, meaning 
+> you can simply replace `conda` with `mamba` for almost all use-cases. 
+> While this tutorial references 'Conda' (as in 'Conda environment' and 
+> 'Conda package' the practical command line examples use `mamba` where 
+> possible.  
+
+What are the benefits of using an environment manager? Some examples include 
+the ability to easily run different versions of the same package, have 
+different cross-package dependencies that are otherwise incompatible with 
+each other and, last but not least, easy installation of all the software 
+needed for an analysis.
 
 Environments are of particular relevance when making bioinformatics projects
 reproducible. Full reproducibility requires the ability to recreate the system

--- a/pages/conda/conda-2-the-basics.md
+++ b/pages/conda/conda-2-the-basics.md
@@ -6,7 +6,7 @@ called *Project A*.
 * Let's make our first Conda environment:
 
 ```bash
-conda create -n project_a -c bioconda fastqc
+mamba create -n project_a -c bioconda fastqc
 ```
 
 This will create an environment called `project_a`, containing FastQC from the
@@ -16,7 +16,7 @@ for your confirmation.
 * Once it is done, you can activate the environment:
 
 ```bash
-conda activate project_a
+mamba activate project_a
 ```
 
 By default, Conda will add information to your prompt telling you which
@@ -25,7 +25,7 @@ environment that is active.
 * To see all your environments you can run:
 
 ```bash
-conda info --envs
+mamba info --envs
 ```
 
 The active environment will be marked with an asterisk.
@@ -34,13 +34,13 @@ The active environment will be marked with an asterisk.
   run:
 
 ```bash
-conda list
+mamba list
 ```
 
 * To save the installed packages to a file, run:
 
 ```bash
-conda env export --from-history > environment.yml
+mamba env export --from-history > environment.yml
 ```
 
 where `--from-history` only reports the packages requested to be installed 
@@ -68,7 +68,7 @@ activated.
   install`. Make sure that `project_a` is the active environment first.
 
 ```bash
-conda install -c bioconda sra-tools
+mamba install -c bioconda sra-tools
 ```
 
 * If we don't specify the package version, the latest available version will be
@@ -76,13 +76,13 @@ conda install -c bioconda sra-tools
 * Run the following to see what versions are available:
 
 ```bash
-conda search -c bioconda sra-tools
+mamba search -c bioconda sra-tools
 ```
 
 * Now try to install a different version of SRA-Tools, *e.g.*:
 
 ```bash
-conda install -c bioconda sra-tools=2.7.0
+mamba install -c bioconda sra-tools=2.7.0
 ```
 
 Read the information that Conda displays in the terminal. It probably asks if
@@ -111,7 +111,7 @@ new Project A where you want the latest version.
 * Make a new environment for your old project:
 
 ```bash
-conda create -n project_old -c bioconda bowtie2=2.2.5
+mamba create -n project_old -c bioconda bowtie2=2.2.5
 ```
 
 * List your environments (do you remember the command?).
@@ -123,14 +123,14 @@ conda create -n project_old -c bioconda bowtie2=2.2.5
 Now let's try to remove an installed package from the active environment:
 
 ```
-conda remove sra-tools
+mamba remove sra-tools
 ```
 
-* Run `conda deactivate` to exit your active environment.
+* Run `mamba deactivate` to exit your active environment.
 * Now, let's remove an environment:
 
 ```bash
-conda env remove -n project_old
+mamba env remove -n project_old
 ```
 
 After making a few different environments and installing a bunch of packages,
@@ -138,7 +138,7 @@ Conda can take up some disk space. You can remove unnecessary files with the
 command:
 
 ```bash
-conda clean -a
+mamba clean -a
 ```
 
 This will remove package tar-balls that are left from package installations,
@@ -148,6 +148,6 @@ data.
 > **Quick recap** <br>
 > In this section we've learned:
 >
-> - How to use `conda install` for installing packages on the fly.
+> - How to use `mamba install` for installing packages on the fly.
 > - How to create, activate and change between environments.
 > - How to remove packages or environments and clean up.

--- a/pages/conda/conda-3-projects.md
+++ b/pages/conda/conda-3-projects.md
@@ -1,9 +1,9 @@
 We have up until now specified which Conda packages to install directly on the
-command line using the `conda create` and `conda install` commands. For working
+command line using the `mamba create` and `mamba install` commands. For working
 in projects this is not the recommended way. Instead, for increased control and
-reproducibility, it is better to use an *environment file* (in [YAML format](https://en.wikipedia.org/wiki/YAML))
-that specifies the packages, versions and channels needed to create the
-environment for a project.
+reproducibility, it is better to use an *environment file*  (in [YAML format]
+(https://en.wikipedia.org/wiki/YAML)) that specifies the packages, versions 
+and channels needed to create the environment for a project.
 
 Throughout these tutorials we will use a case study where we analyze an RNA-seq
 experiment with the multiresistant bacteria MRSA (see [intro](introduction)).
@@ -35,11 +35,11 @@ dependencies:
 ```
 
 * Now, make a new Conda environment from the YAML file (note that here the
-  command is `conda env create` as opposed to `conda create` that we used
-  above):
+  command is `mamba env create` as opposed to `mamba create` that we used
+  before):
 
 ```bash
-conda env create -n project_mrsa -f environment.yml
+mamba env create -n project_mrsa -f environment.yml
 ```
 
 > **Tip** <br>
@@ -53,7 +53,8 @@ conda env create -n project_mrsa -f environment.yml
 > contain the Conda environment inside the project directory, which does make
 > sense from a reproducibility perspective, and makes it easier to keep track
 > of what environment belongs to what project. If you don't specify `-p` the
-> environment will be installed in the default `miniconda3/envs/` directory.
+> environment will be installed in the `envs/` directory inside your 
+> Mamba/Conda installation path.
 
 * Activate the environment!
 
@@ -106,66 +107,39 @@ daunting to try to capture all of that in a single Conda environment, especially
 when you consider potential incompatibilities that may arise. It can therefore
 be a good idea to start new projects with an environment file with each package
 you know that you will need to use, but without specifying exact versions
-(except for those packages where you *know* you need a specific version). Conda
-will then try to get the latest compatible versions of all the specified
+(except for those packages where you *know* you need a specific version). 
+This will install the latest compatible versions of all the specified 
 software, making the start-up and installation part of new projects easier. You
 can then add the versions that were installed to your environment file
 afterwards, ensuring future reproducibility.
 
-There is one command that can make this easier: `conda env export`. This allows
+There is one command that can make this easier: `mamba env export`. This allows
 you to export a list of the packages you've already installed, including their
 specific versions, meaning you can easily add them after the fact to your
 environment file. If you use the `--no-builds` flag, you'll get a list of the
 packages minus their OS-specific build specifications, which is more useful for
 making the environment portable across systems. This way, you can start with an
-environment file with just the packages you need (without version), allow Conda
-to solve the dependency tree and install the most up-to-date version possible,
-and then add the resulting version back in to the environment file using the
-`export` command!
+environment file with just the packages you need (without version), which will 
+install the most up-to-date version possible, and then add the resulting 
+version back in to the environment file using the `export` command!
 
-# Optimising for speed
-
-One of the greatest strengths of Conda is, unfortunately, also its greatest
-weakness in its current implementation: the availability of a frankly enormous
-number of packages and versions. This means that the search space for the
-dependency hierarchy of any given Conda environment can become equally enormous,
-leading to a (at times) ridiculous execution time for the dependency solver. It
-is not uncommon to find yourself waiting for minutes for Conda to solve
-a dependency hierarchy, sometimes even into the double digits. How can this be
-circumvented?
-
-Firstly, it is useful to specify as many of the `major.minor.patch` version
-numbers as possible when defining your environment: this drastically reduces the
-search space that Conda needs to go through. This is not always possible,
-though. For example, we mentioned in the end of the *Environments in projects*
-section that you might want to start out new projects without version
-specifications for most packages, which means that the search space is going to
-be large. Here is where another software comes into play: *Mamba*.
-
-The [Mamba package manager](https://github.com/mamba-org/mamba) is built on-top
-of Conda with some changes and additions that greatly speed up the execution
-time. First of all, core parts of Mamba are written in C++ instead of Python,
-like the original Conda. Secondly, it uses a different dependency solver
-algorithm which is much faster than the one Conda uses. Lastly, it allows for
-parallel downloading of repository data and package files with multi-threading.
-All in all, these changes mean that Mamba is (currently) simply a better
-version of Conda. Hopefully these changes will be incorporated into the Conda
-core at some point in the future!
-
-So, how do you get Mamba? Funnily enough, the easiest way to install it is (of
-course) using Conda! Just run `conda install -n base -c conda-forge mamba`,
-which will install Mamba in your `base` Conda environment. Mamba works almost
-exactly the same as Conda, meaning that all you need to do is to stop using
-`conda command` and instead use `mamba command` - simple! Be aware though that
-in order to use `mamba activate` and `mamba deactivate` you first need to run
-`mamba init`. So transitioning into using Mamba is actually quite easy - enjoy 
-your shorter execution times!
+> **Optimised for speed** <br>
+> The availability of an enormous number of packages and versions means that 
+> the search space for the dependency hierarchy of any given Conda environment 
+> can become equally enormous, leading to a (at times) ridiculous execution 
+> time for the dependency solver.
+> Fortunately, with the introduction of the Mamba reimplementation of Conda the 
+> time needed to install environments is greatly reduced. First of all, core 
+> parts of Mamba are written in C++ instead of Python, like the original Conda.
+> Secondly, it uses a different dependency solver algorithm which is much 
+> faster than the one Conda uses. Lastly, it allows for parallel downloading 
+> of repository data and package files with multi-threading. All in all, these 
+> changes mean that Mamba is (currently) simply a better version of Conda.
 
 > **Quick recap** <br>
 > In this section we've learned:
 >
 > - How to define our Conda environment using a YAML-file.
-> - How to use `conda env create` to make a new environment from a YAML-file.
-> - How to use `conda env export` to get a list of installed packages.
-> - How to work with Conda in a project-like setting.
-> - How to optimise Conda for speed.
+> - How to use `mamba env create` to make a new environment from a YAML-file.
+> - How to use `mamba env export` to get a list of installed packages.
+> - How to work in a project-like setting.

--- a/pages/conda/conda-4-extra-material.md
+++ b/pages/conda/conda-4-extra-material.md
@@ -1,11 +1,12 @@
 The following extra material contains some more advanced things you can do with
-Conda and the command line in general, which is not part of the main course
-materials. All the essential skills of Conda are covered by the previous
+Conda/Mamba and the command line in general, which is not part of the main 
+course materials. All the essential skills of are covered by the previous
 section: the material here should be considered tips and tricks from people who
-use Conda as part of their daily work. You thus don't need to use these things
-unless you want to, and you can even skip this part of the lesson if you like!
+use Conda/Mamba as part of their daily work. You thus don't need to use these 
+things unless you want to, and you can even skip this part of the lesson if 
+you like!
 
-## Configuring Conda
+## Configuration
 
 The behaviour of your Conda installation can be changed using an optional
 configuration file `.condarc`. On a fresh Conda install no such file is
@@ -71,31 +72,32 @@ page.
 
 ## Managing Python versions
 
-With Conda it's possible to keep several different versions of Python on your
-computer at the same time, and switching between these versions is very easy.
-However, a single Conda environment can only contain one version of Python.
+With Conda environments it's possible to keep several different versions of 
+Python on your computer at the same time, and switching between these 
+versions is very easy. However, a single Conda environment can only contain 
+one version of Python.
 
 ### Your current Python installation
 
-The Conda base environment has its own version of Python installed.
-When you open a terminal (after having installed Conda on your system) this base
-environment is activated by default (as evidenced by `(base)` prepended to your
-prompt). You can check what Python version is installed in this environment by
-running `python --version`. To see the exact path to the Python executable type
-`which python`.
+The `base` environment has its own version of Python installed.
+When you open a terminal (after having installed Conda/Mamba on your system) 
+this base environment is activated by default (as evidenced by `(base)` 
+prepended to your prompt). You can check what Python version is installed in 
+this environment by running `python --version`. To see the exact path to the 
+Python executable type `which python`.
 
 In addition to this your computer may already have Python installed in a
-separate (system-wide) location outside of the Conda installation. To see if
-that is the case type `conda deactivate` until your prompt is not prepended
-with a Conda environment name. Then type `which python`. If a path was printed
-to the terminal (*e.g.* `/usr/bin/python`) that means some Python version is
-already installed in that location. Check what version it is by typing `python
---version`.
+separate (system-wide) location outside of the Conda/Mamba installation. To 
+see if that is the case type `mamba deactivate` until your prompt is not 
+prepended with a Conda environment name. Then type `which python`. If a path 
+was printed to the terminal (*e.g.* `/usr/bin/python`) that means some 
+Python version is already installed in that location. Check what version it 
+is by typing `python --version`.
 
-Now activate the base Conda environment again by typing `conda activate` (or
-the equivalent `conda activate base`) then check the Python installation path
+Now activate the `base` environment again by typing `mamba activate` (or
+the equivalent `mamba activate base`) then check the Python installation path
 and version using `which` and `python --version` as above. See the difference?
-When you activate a Conda environment your `$PATH` variable is updated so that
+When you activate an environment your `$PATH` variable is updated so that
 when you call `python` (or any other program) the system first searches the
 directory of the currently active environment.
 
@@ -106,7 +108,7 @@ version of Python in that environment as well. As an example, create an
 environment containing Python version `3.5` by running:
 
 ```bash
-conda create -n py35 python=3.5
+mamba create -n py35 python=3.5
 ```
 
 Here we name the environment `py35` but you can choose whatever name you want.
@@ -114,7 +116,7 @@ Here we name the environment `py35` but you can choose whatever name you want.
 To activate the environment run:
 
 ```bash
-conda activate py35
+mamba activate py35
 ```
 
 You now have a completely separate environment with its own Python version.
@@ -125,33 +127,32 @@ Python 2.x and are thus incompatible with Python 3.x. Simply create the new
 Conda environment with:
 
 ```bash
-conda create -n py27 python=2.7
+mamba create -n py27 python=2.7
 ```
 
 Activate this environment with:
 
 ```bash
-conda activate py27
+mamba activate py27
 ```
 
-Now, switching between Python versions is as easy as typing `conda activate
-py35` / `conda activate py27`.
+Now, switching between Python versions is as easy as typing `mamba activate
+py35` / `mamba activate py27`.
 
 > **Note**<br>
 > If you create an environment where none of the packages require Python,
 > *and* you don't explicitly install the `python` package then that new
-> environment will use the Python version installed in your base Conda
-> environment.
+> environment will use the Python version installed in your `base` environment.
 
 ## Decorating your prompt
 
-By default, Conda adds the name of the currently activated environment to the
-end of your command line prompt. This is a good thing, as it makes it easier to
-keep track of what environment and packages you have access to. The way this is
+By default, the name of the currently activated environment is added to your 
+command line prompt. This is a good thing, as it makes it easier to keep 
+track of what environment and packages you have access to. The way this is
 done in the default implementation becomes an issue when using absolute paths
-for environments (specifying `conda env create -p path/to/environment`,
+for environments (specifying `mamba env create -p path/to/environment`,
 though, as the entire path will be added to the prompt. This can take up a lot
-of unnecessary space, but can be solved in a number of ways.
+of unnecessary space on your screen, but can be solved in a number of ways.
 
 The most straightforward way to solve this is to change the Conda configuration
 file, specifically the settings of the `env_prompt` configuration value which
@@ -177,7 +178,7 @@ As an example, say you have a project called *project_a* with the project path
 `~/myprojects/project_a`. You could then install the environment for *project_a*
 into a folder `~/myprojects/project_a/envs/project_a_environment`. Activating
 the environment by pointing Conda to it (*e.g.*
-`conda activate ~/myprojects/project_a/envs/project_a_environment`) will only
+`mamba activate ~/myprojects/project_a/envs/project_a_environment`) will only
 cause your prompt to be modified with *project_a_environment*.
 
 ## Bash aliases for conda
@@ -189,11 +190,11 @@ Two aliases that might be usefol for you are `alias coac='conda activate'` and
 
 ## Rolling back to an earlier version of the environment
 
-Conda keeps a history of the changes to an environment. You can see 
-revisions to an environment by using:
+The history of the changes to an environment are automatically tracked. You can 
+see revisions to an environment by using:
 
 ```bash
-conda list --revisions
+mamba list --revisions
 ```
 
 which shows each revision (numbered) and what's installed.
@@ -201,5 +202,5 @@ which shows each revision (numbered) and what's installed.
 You can revert back to particular revision using:
 
 ```bash
-conda install --revision 5
+mamba install --revision 5
 ```

--- a/pages/containers/containers-3-building-images.md
+++ b/pages/containers/containers-3-building-images.md
@@ -50,7 +50,7 @@ repositories](https://hub.docker.com/explore/). There are many roads to Rome
 when it comes to choosing the best image to start from. Say you want to run
 RStudio in a Conda environment through a Jupyter notebook. You could then start
 from one of the [rocker images](https://github.com/rocker-org/rocker) for R,
-a [Miniconda image](https://hub.docker.com/r/continuumio/miniconda/), or
+a [Mambaforge image](https://hub.docker.com/r/condaforge/mambaforge), or
 a [Jupyter image](https://hub.docker.com/r/jupyter/). Or you just start from
 one of the low-level official images and set up everything from scratch.
 `LABEL` and `MAINTAINER` is just meta-data that can be used for organizing your

--- a/pages/course-information/pre-course-setup.md
+++ b/pages/course-information/pre-course-setup.md
@@ -198,6 +198,13 @@ effect. You can verify that the installation worked by running:
 mamba --version
 ```
 
+> **Important!** <br>
+> The Mamba docs specify a couple of things to keep in mind when using Mamba.
+> First of all, `mamba` should be installed in the `base` environment and no
+> other packages should be installed into `base`. Furthermore, mixing of the
+> `conda-forge` and `defaults` channels should be avoided as the default 
+> Anaconda channels are incompatible with `conda-forge`.
+
 > **Different Mambas/Condas** <br>
 > You may come across several flavours of both Mamba and Conda. For Mamba there's the *Miniforge* installer 
 > which allows you to install the `mamba` command line tool that works as a replacement for `conda`. There's also 
@@ -208,14 +215,14 @@ mamba --version
 
 ### Configuring Conda
 
-At the moment the `config` subcommand is not implemented in `mamba`. This means that when you want to 
-configure your mamba or conda installation you still need to rely on `conda`.  
+At the moment the `config` subcommand is not implemented in `mamba`. This means 
+that when you want to configure your mamba or conda installation you still 
+need to rely on `conda`.  
 
-As a last step we will set up the default channels (from where packages will be searched for and downloaded if no 
-channel is specified):
+As a last step we will set up the default channels (from where packages will be 
+searched for and downloaded if no channel is specified):
 
 ```
-conda config --add channels defaults
 conda config --add channels bioconda
 conda config --add channels conda-forge
 ```

--- a/pages/course-information/pre-course-setup.md
+++ b/pages/course-information/pre-course-setup.md
@@ -211,13 +211,20 @@ mamba --version
 At the moment the `config` subcommand is not implemented in `mamba`. This means that when you want to 
 configure your mamba or conda installation you still need to rely on `conda`.  
 
-As a last step we will setup the default channels (from where packages will be searched for and downloaded if no 
+As a last step we will set up the default channels (from where packages will be searched for and downloaded if no 
 channel is specified):
 
 ```
 conda config --add channels defaults
 conda config --add channels bioconda
 conda config --add channels conda-forge
+```
+
+and we will also set so called 'strict' channel priority, which ensures higher stability and better performance (see 
+details about this setting by running `conda config --describe channel_priority`):
+
+```
+conda config --set channel_priority strict
 ```
 
 ## Installing Snakemake

--- a/pages/course-information/pre-course-setup.md
+++ b/pages/course-information/pre-course-setup.md
@@ -60,6 +60,10 @@ resources:
 > nameserver to the internet configuration by running `sudo nano /etc/resolv.conf`
 > then add `nameserver 8.8.8.8` to the bottom of the file and save it.
 
+> **Important!** <br>
+> Whenever a setup instruction specifies Mac or Linux (*i.e.* only those two, with no alternative for Windows), 
+> **please follow the Linux instructions.**
+
 Open a bash shell Linux terminal and clone the GitHub repository containing all
 files you will need for completing the tutorials as follows. First, `cd` into
 a directory on your computer (or create one) where it makes sense to download
@@ -77,20 +81,6 @@ cd /path/to/your/directory
 git clone https://github.com/NBISweden/workshop-reproducible-research.git
 cd workshop-reproducible-research
 ```
-
-Whenever a setup instruction specifies Mac or Linux (*i.e.* only those two,
-with no alternative for Windows), please follow the Linux instructions.
-
-> **Tip** <br>
-> If you want to revisit the material from an older instance of this course,
-> you can do that using `git checkout tags/<tag-name>`, *e.g.* `git checkout
-> tags/course_1905`. To list all available tags, use `git tag`. Run this
-> command after you have `cd` into `workshop-reproducible-research` as
-> described above. If you do that, you probably also want to view the
-> same older version of this website. Until spring 2021, the website was
-> hosted at https://nbis-reproducible-research.readthedocs.io/en/latest/.
-> Locate the version box in the bottom right corner of the website and
-> select the corresponding version.
 
 ## Installing Git
 
@@ -144,63 +134,85 @@ below for more information.
 > instead of using a hard-coded `master`. We at NBIS want to be a part of this
 > change, so we have chosen to use `main` for this course.
 
-## Installing Conda
+> **Tip** <br>
+> If you want to revisit the material from an older instance of this course,
+> you can do that using `git checkout tags/<tag-name>`, *e.g.* `git checkout
+> tags/course_1905`. To list all available tags, use `git tag`. Run this
+> command after you have `cd` into `workshop-reproducible-research` as
+> described above. If you do that, you probably also want to view the
+> same older version of this website. Until spring 2021, the website was
+> hosted at https://nbis-reproducible-research.readthedocs.io/en/latest/.
+> Locate the version box in the bottom right corner of the website and
+> select the corresponding version.
 
-Conda is installed by downloading and executing an installer from the Conda
-website, but which version you need depends on your operating system:
+## Installing Mamba
+
+> **Mamba or Conda?** <br>
+> Maybe you've worked with the Conda package manager before, and you're wondering
+> what the heck Mamba is? Mamba is simply put a faster implementation of Conda
+> and has quickly grown and matured to the point that we are making the switch
+> to Mamba also in this course. Conveniently there is almost no difference in 
+> the way the two programs work on the command line. You simply change `conda`
+> to `mamba` and keep working as you've done before (see the exception under 
+> "Configuring Conda" below).
+> This also means that if you already have conda installed you can keep using
+> it for this course, however we strongly recommend you to try out mamba in 
+> order to make your environment managing more efficient.
+> You will notice that we still use the terms 'Conda environment', 'Conda 
+> packages' _etc._ throughout the course and that the tutorial pages still have
+> 'Conda' in the title. This is because Conda is the original package manager
+> with a widely adopted terminology, and Mamba is a reimplementation of Conda.
+> We hope this is not too confusing.
+
+Mamba is installed by downloading and executing a [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge)
+installer for your operating system.
 
 ```bash
-# Install Miniconda3 for 64-bit Mac
-curl -L https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-MacOSX-x86_64.sh -O
-bash Miniconda3-4.7.12.1-MacOSX-x86_64.sh
-rm Miniconda3-4.7.12.1-MacOSX-x86_64.sh
+# Install Mambaforge3 for 64-bit Mac
+curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-x86_64.sh -O
+bash Mambaforge-MacOSX-x86_64.sh
+rm Mambaforge-MacOSX-x86_64.sh
 ```
 
 ```bash
-# Install Miniconda3 for 64-bit Linux
-curl -L https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O
-bash Miniconda3-4.7.12.1-Linux-x86_64.sh
-rm Miniconda3-4.7.12.1-Linux-x86_64.sh
+# Install Mambaforge3 for 64-bit Linux
+curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh -O 
+bash Mambaforge-Linux-x86_64.sh
+rm Mambaforge-Linux-x86_64.sh
 ```
 
 > **Attention!** <br>
-> If you already have installed Conda but want to update, you should be able
-> to simply run `conda update conda` and subsequently `conda init`, and skip
-> the installation instructions below.
-
-> **Apple M1 Chips** <br>
-> If you have a newer Apple computer with an M1 chip, make sure you have
-> installed [Rosetta](https://support.apple.com/en-us/HT211861) before you run
-> the installer. If you want to more fully utilise the new architecture,
-head over to [Miniforge](https://github.com/conda-forge/miniforge#miniforge3)!
+> If you already have installed Mamba but want to update, you should be able to simply 
+> run `mamba update mamba` and subsequently `mamba init`, and skip the installation instructions below.
 
 The installer will ask you questions during the installation:
 
 - Do you accept the license terms? (Yes)
-- Do you accept the installation path or do you want to choose a different one?
-  (Probably yes)
-- Do you want to run `conda init` to setup Conda on your system? (Yes)
+- Do you accept the installation path or do you want to choose a different one? (Probably yes)
+- Do you want the installer to initialize Mambaforge (Yes)
 
 Restart your shell so that the settings in `~/.bashrc`/`~/.bash_profile` can take
 effect. You can verify that the installation worked by running:
 
 ```bash
-conda --version
+mamba --version
 ```
 
-> **Different Condas** <br>
-> There are three Conda-related things you may have encountered: the first is
-> *Conda*, the package and environment manager we've been talking about so far.
-> Second is *Miniconda*, which is the installer for Conda. The third is
-> *Anaconda*, which is a distribution of not only Conda, but also over 150
-> scientific Python packages. It's generally better to stick with only Conda,
-> *i.e.* installing with Miniconda, rather than installing 3 GB worth of
-> packages you may not even use.
+> **Different Mambas/Condas** <br>
+> You may come across several flavours of both Mamba and Conda. For Mamba there's the *Miniforge* installer 
+> which allows you to install the `mamba` command line tool that works as a replacement for `conda`. There's also 
+> `micromamba`, a small standalone C++ program developed mainly for continuous integration pipelines.
+> For Conda there's *Miniconda*, which is the installer for Conda. The third is *Anaconda*, which is a distribution 
+> of not only Conda, but also over 150 scientific Python packages. If you want to use Conda it's generally better to 
+> stick with the Miniconda installation, rather than installing 3 GB worth of packages you may not even use.
 
 ### Configuring Conda
 
-Lastly, we will setup the default channels (from where packages will be searched
-for and downloaded if no channel is specified).
+At the moment the `config` subcommand is not implemented in `mamba`. This means that when you want to 
+configure your mamba or conda installation you still need to rely on `conda`.  
+
+As a last step we will setup the default channels (from where packages will be searched for and downloaded if no 
+channel is specified):
 
 ```
 conda config --add channels defaults

--- a/pages/course-information/pre-course-setup.md
+++ b/pages/course-information/pre-course-setup.md
@@ -164,6 +164,28 @@ below for more information.
 > with a widely adopted terminology, and Mamba is a reimplementation of Conda.
 > We hope this is not too confusing.
 
+### If you already have Mamba installed
+
+If you already have installed Mamba you can make sure you're using the latest 
+version by running `mamba update -n base mamba` and skip the installation 
+instructions below.
+
+### If you have Conda installed
+
+Install `mamba` from the `conda-forge` channel into your base environment:
+
+```
+conda install mamba -n base mamba -c conda-forge
+```
+
+Check that installation worked by running:
+
+```
+mamba --version
+```
+
+### If you have neither Mamba nor Conda installed
+
 Mamba is installed by downloading and executing a [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge)
 installer for your operating system.
 
@@ -180,10 +202,6 @@ curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaf
 bash Mambaforge-Linux-x86_64.sh
 rm Mambaforge-Linux-x86_64.sh
 ```
-
-> **Attention!** <br>
-> If you already have installed Mamba but want to update, you should be able to simply 
-> run `mamba update mamba` and subsequently `mamba init`, and skip the installation instructions below.
 
 The installer will ask you questions during the installation:
 
@@ -213,7 +231,7 @@ mamba --version
 > of not only Conda, but also over 150 scientific Python packages. If you want to use Conda it's generally better to 
 > stick with the Miniconda installation, rather than installing 3 GB worth of packages you may not even use.
 
-### Configuring Conda
+### Configuring Mamba/Conda
 
 At the moment the `config` subcommand is not implemented in `mamba`. This means 
 that when you want to configure your mamba or conda installation you still 

--- a/pages/course-information/take-down.md
+++ b/pages/course-information/take-down.md
@@ -8,47 +8,57 @@ Explorer or `rm -rf workshop-reproducible-research`. Note that this will also
 delete the hidden directories `.git`, which contains the history of the repo,
 and `.snakemake`, which contains the history of any Snakemake runs.
 
-## Conda
+## Mamba
 
-Several of the tutorials use Conda for installing packages. This amounts to
-about 2.6 GB if you've done all the tutorials. If you plan on using Conda in
+Several of the tutorials use Mamba for installing packages. This amounts to
+about 2.6 GB if you've done all the tutorials. If you plan on using Mamba in
 the future you can remove just the packages, or you can remove everything
-including Conda itself. 
+including Mamba itself. 
 
-In order to remove all your Conda environments, you first need to list them:
+In order to remove all your environments, you first need to list them:
 
 ```bash
-conda env list
+mamba env list
 ```
 
 For each of the environments except "base" run the following:
 
 ```bash
-conda remove -n envname --all
+mamba remove -n <envname> --all
 ```
 
 And, finally:
 
 ```bash
-conda clean --all
+mamba clean --all
 ```
 
-If you also want to remove Conda itself (*i.e.* removing all traces of Conda),
-you need to check where Conda is installed. Look for the row "base environment".
+If you also want to remove Mamba itself (*i.e.* removing all traces of Mamba),
+you should first 'uninit' the installation, this part should be run with 
+`conda`:
+
+```
+conda init --reverse
+```
+
+Now find the path where Mamba is installed. Look for the row "base 
+environment":
 
 ```bash
-conda info
+mamba info | grep "base environment"
 ```
 
-This should say something like `/Users/<user>/miniconda3`. Then remove the
-entire Conda directory:
+This should say something like:
 
 ```
-rm -rf /Users/<user>/miniconda3
+base environment : /Users/<user>/mambaforge  (writable). 
 ```
 
-Lastly, open your `~/.bashrc` file (or `~/.bash_profile` if on Mac) in a text
-editor and remove the path to Conda from PATH.
+Then remove the entire Mambaforge directory:
+
+```
+rm -rf /Users/<user>/mambaforge
+```
 
 ## Snakemake
 

--- a/pages/jupyter/jupyter-6-extensions.md
+++ b/pages/jupyter/jupyter-6-extensions.md
@@ -1,6 +1,6 @@
 Jupyter Notebook extensions are add-ons that can increase the functionality of
 your notebooks. These were installed in the [setup](pre-course-setup) section for this 
-tutorial by including the `jupyter_contrib_nbextensions` package in the conda
+tutorial by including the `jupyter_contrib_nbextensions` package in the Conda
 environment file. You can read more about the extensions 
 [here](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/). 
 

--- a/pages/jupyter/jupyter-8-the-mrsa-case-study.md
+++ b/pages/jupyter/jupyter-8-the-mrsa-case-study.md
@@ -180,12 +180,12 @@ from IPython.display import Image
 Image(rulegraph_file)
 ```
 
-Let's also output the full conda environment so that all packages and versions 
+Let's also output the full environment so that all packages and versions 
 are included in the notebook. There are several ways this can be done, for 
 example you could simply add:
 
 ```python
-!conda list
+!mamba list
 ```
 
 to the end of the notebook.

--- a/pages/jupyter/jupyter-9-extra-material.md
+++ b/pages/jupyter/jupyter-9-extra-material.md
@@ -16,7 +16,13 @@ general:
 ssh <your-user-name>@rackham1.uppmax.uu.se
 ```
 
-* Create/activate a conda environment containing `jupyter` then run:
+* Create/activate a Conda environment containing `jupyter`, _e.g._:
+
+```
+mamba create -n jupyter -c conda-forge jupyter
+```
+
+* activate the environment, then run:
 
 ```
 jupyter notebook 
@@ -104,8 +110,8 @@ rule make_supplementary:
 > **Note** <br>
 > The Conda enivronment for the jupyter tutorial does not contain packages
 > required to run the full snakemake workflow. So if you wish to test jupyter
-> integration fully you should update the conda environment by running 
-> `conda install snakemake-minimal fastqc sra-tools multiqc bowtie2 tbb 
+> integration fully you should update the environment by running 
+> `mamba install snakemake-minimal fastqc sra-tools multiqc bowtie2 tbb 
 > samtools htseq bedtools wget graphviz`
 
 ## More integrations
@@ -242,12 +248,12 @@ snakemake -j 1 make_supplementary_plots
 ## Presentations with Jupyter
 
 As if all the above wasn't enough you can also create presentations/slideshows
-with Jupyter! Simply use conda to install the 
+with Jupyter! Simply use mamba to install the 
 [RISE](https://rise.readthedocs.io/en/stable/) extension to your jupyter 
 environment:
 
 ```bash
-conda install -c conda-forge rise
+mamba install -c conda-forge rise
 ```
 
 then open up a notebook of your choice. In the menu click **View** -> **Cell 

--- a/pages/rmarkdown/r-markdown-6-the-mrsa-case-study.md
+++ b/pages/rmarkdown/r-markdown-6-the-mrsa-case-study.md
@@ -221,7 +221,7 @@ out.height = "11cm"
 > a Snakemake or Nextflow workflow. This is something we do for the final
 > version of the MRSA project (in the Containers tutorial). In such cases it is
 > advisable to manage the installation of R and required R packages through
-> your conda environment file and use the `rmarkdown::render()` command from
+> your Conda environment file and use the `rmarkdown::render()` command from
 > the shell section of your Snakemake rule or Nexflow process.
 
 > **Quick recap** <br>

--- a/pages/snakemake/snakemake-11-extra-material.md
+++ b/pages/snakemake/snakemake-11-extra-material.md
@@ -136,7 +136,7 @@ that is used _e.g._ on Uppmax.
 
 The SLURM Profile needs to be set up with the software
 [cookiecutter](https://cookiecutter.readthedocs.io/) which you can install with
-conda: `conda install -c conda-forge cookiecutter`.
+mamba: `mamba install -c conda-forge cookiecutter`.
 
 During the [setup](https://github.com/Snakemake-Profiles/slurm#quickstart) of 
 the profile you will be asked for several values for your Profile. To configure

--- a/pages/snakemake/snakemake-3-visualising-workflows.md
+++ b/pages/snakemake/snakemake-3-visualising-workflows.md
@@ -150,7 +150,7 @@ a re-run.
 
 Snakemake is aware of changes to four categories of such "rerun-triggers": 
 "input" (changes to rule input files), "params" (changes to the rule `params` section),
-"software-env" (changes to conda environment files specified by the `conda:` 
+"software-env" (changes to Conda environment files specified by the `conda:` 
 directive) and "code" (changes to code in the `shell:`, `run:`, `script:` and 
 `notebook:` directives). 
 

--- a/pages/snakemake/snakemake-4-the-mrsa-workflow.md
+++ b/pages/snakemake/snakemake-4-the-mrsa-workflow.md
@@ -12,7 +12,7 @@ workflow to make it more flexible and reproducible!
 > modifications is available in `tutorials/git/Snakefile`.
 
 You are probably already in your `snakemake-env` environment, otherwise
-activate it (use `conda info --envs` if you are unsure).
+activate it (use `mamba info --envs` if you are unsure).
 
 > **Tip** <br>
 > Here we have one Conda environment for executing the whole Snakemake
@@ -21,7 +21,10 @@ activate it (use `conda info --envs` if you are unsure).
 > rule-specific-env.yml` in the rule definition and running Snakemake with
 > the `--use-conda` flag. The given rule will then be run in the Conda
 > environment specified in `rule-specific-env.yml` that will be created and
-> activated on the fly by Snakemake.
+> activated on the fly by Snakemake. Note that by default Snakemake uses 
+> `mamba` to generate the rule-specific environments. This behaviour can be 
+> changed by running with `--conda-frontend conda`, which will force 
+> Snakemake to use `conda` instead.
 
 Let's start by generating the rule graph so that we get an overview of the
 workflow.

--- a/tutorials/containers/environment.yml
+++ b/tutorials/containers/environment.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - main
   - r
 dependencies:
   - python=3.9.12

--- a/tutorials/git/environment.yml
+++ b/tutorials/git/environment.yml
@@ -2,7 +2,6 @@ name: git-env
 channels:
   - conda-forge
   - bioconda
-  - main
   - r
 dependencies:
   - python=3.9.12

--- a/tutorials/jupyter/environment.yml
+++ b/tutorials/jupyter/environment.yml
@@ -2,7 +2,6 @@ name: jupyter-env
 channels:
   - conda-forge
   - bioconda
-  - main
 dependencies:
   - python=3.9.7
   - biopython=1.79

--- a/tutorials/nextflow/environment.yml
+++ b/tutorials/nextflow/environment.yml
@@ -2,7 +2,6 @@ name: nextflow-env
 channels:
   - conda-forge
   - bioconda
-  - main
   - r
 dependencies:
   - fastqc=0.11.9

--- a/tutorials/rmarkdown/environment.yml
+++ b/tutorials/rmarkdown/environment.yml
@@ -3,7 +3,6 @@ channels:
   - r
   - conda-forge
   - bioconda
-  - main
 dependencies:
   - bioconductor-geoquery=2.54.0
   - bioconductor-rtracklayer=1.46.0

--- a/tutorials/snakemake/environment.yml
+++ b/tutorials/snakemake/environment.yml
@@ -2,7 +2,6 @@ name: snakemake-env
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.9.12
   - fastqc=0.11.9


### PR DESCRIPTION
This PR attempts to make a more dedicated switch from `conda` to `mamba`.

Mention of `mamba` as a faster alternative to `conda` has been around in the course material for a long time but we haven't put forth Mamba as the first-choice package manager. From the students perspective this change may be confusing because the 'Conda' terminology is still around (_e.g._ 'Conda environment' and 'Conda package') and because Mamba still relies on Conda for some functionality. However, Mamba has grown and has become adopted by such a large part of the bioinformatics community that it may be worthwhile to advocate using it as the first go-to implementation for managing Conda environments.