### PR TITLE
Figshare data

### DIFF
--- a/pages/conda/conda-2-the-basics.md
+++ b/pages/conda/conda-2-the-basics.md
@@ -64,30 +64,30 @@ activated.
 
 # Adding more packages
 
-* Now, let's add another package (*SRA-Tools*) to our environment using `conda
+* Now, let's add another package (*seqtk*) to our environment using `conda
   install`. Make sure that `project_a` is the active environment first.
 
 ```bash
-conda install -c bioconda sra-tools
+conda install -c bioconda seqtk
 ```
 
 * If we don't specify the package version, the latest available version will be
-  installed. What version of SRA-Tools got installed?
+  installed. What version of seqtk got installed?
 * Run the following to see what versions are available:
 
 ```bash
-conda search -c bioconda sra-tools
+conda search -c bioconda seqtk
 ```
 
 * Now try to install a different version of SRA-Tools, *e.g.*:
 
 ```bash
-conda install -c bioconda sra-tools=2.7.0
+conda install -c bioconda seqtk=1.2
 ```
 
 Read the information that Conda displays in the terminal. It probably asks if
 you want to downgrade the initial SRA-Tools installation to the one specified
-here (`2.7.0` in the example). You can only have one version of a given package
+here (`1.2` in the example). You can only have one version of a given package
 in a given environment.
 
 Let's assume that you will have sequencing data in your Project A, and want to
@@ -123,7 +123,7 @@ conda create -n project_old -c bioconda bowtie2=2.2.5
 Now let's try to remove an installed package from the active environment:
 
 ```
-conda remove sra-tools
+conda remove seqtk
 ```
 
 * Run `conda deactivate` to exit your active environment.

--- a/pages/conda/conda-3-projects.md
+++ b/pages/conda/conda-3-projects.md
@@ -30,8 +30,7 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
-- fastqc=0.11.9
-- sra-tools=2.11.0
+- fastqc=0.12.1
 ```
 
 * Now, make a new Conda environment from the YAML file (note that here the

--- a/pages/course-information/pre-course-setup.md
+++ b/pages/course-information/pre-course-setup.md
@@ -414,19 +414,3 @@ Please follow the Windows-specific instructions at the [Singularity website](htt
 > Version 6.1.28 of "Virtual box for Windows" may not work, please install
 > version 6.1.26 from [here](https://www.virtualbox.org/wiki/Download_Old_Builds_6_1)
 > in case you encounter problems when trying to start the Vagrant VirtualBox.
-
-## Testing sra-tools
-On some computers we've found that the package `sra-tools` which is used in the
-course is not working properly. The error seems to be related to some certificate
-used to communicate with remote read archives and may affect all environments
-with `sra-tools` on the dependency list.
-
-If you run into errors with the program `fastq-dump` from the `sra-tools` package
-try the following:
-
-1. Remove `sra-tools` from the relevant environment: `conda remove sra-tools`
-2. Download the most recent binaries for your operating system from [here](https://github.com/ncbi/sra-tools/wiki/02.-Installing-SRA-Toolkit#the-sra-toolkit-provides-64-bit-binary-installations-for-the-ubuntu-and-centos-linux-distributions-for-mac-os-x-and-for-windows) (example shown for Mac OSX): `curl --output sratoolkit.tar.gz https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/current/sratoolkit.current-mac64.tar.gz`
-3. Create a temporary directory for the installation: `mkdir tmp_out`
-4. Extract the binary files: `tar -C tmp_out -zxvf sratoolkit.tar.gz */bin/*`
-5. Copy binary files into the conda environment: `cp -r tmp_out/*/bin/* $CONDA_PREFIX/bin/`
-6. Remove the downloaded files: `rm -r sratoolkit.tar.gz tmp_out/`

--- a/pages/nextflow/nextflow-2-the-basics.md
+++ b/pages/nextflow/nextflow-2-the-basics.md
@@ -224,6 +224,64 @@ variable. All that's left now is to change the input to our pipeline!
   `.fromPath(["a.txt", "b.txt"])` and try running the pipeline. Make sure it
   works before you move on!
 
+# Viewing channel contents
+
+As our channels become more complicated it is useful to actually check out
+what's inside them: you can do this using the `.view()` operator.
+
+* Add the following to your workflow definition (on a new line) and execute the
+  workflow: `ch_input.view()`. What do you see?
+
+It can be quite useful to inspect channel contents like this when you are
+developing workflows, especially if you are working with tuples, maps and any
+transforming operators in general.
+
+# Input from samplesheets
+
+So far we've been specifying inputs using strings inside the workflow itself,
+but hard-coding inputs like this is not ideal. A better solution is to use
+samplesheets instead, *e.g.* comma- or tab-separated files; this is standard for
+many pipelines, including [nf-core](https://nf-co.re/). Take, for example, the
+following CSV file:
+
+```no-highlight
+a,a.txt
+b,b.txt
+```
+
+This specifies the samples and their respective files on each row. Using such a
+file is much more portable, scalable and overall easier to use than simple
+hard-coding things in the workflow definition itself. We might also include an
+arbitrary number of additional metadata columns, useful for downstream
+processing and analyses. Using contents of files as input can be done using the
+`.splitCsv()` operator, like so:
+
+```nextflow
+ch_input = Channel
+    .fromPath ( "samplesheet.csv" )
+    .splitCsv ()
+```
+
+* Change the input channel definition to the code above and create the
+  `samplesheet.csv` file as shown above.
+
+* Add the `.view()` operator somewhere to show the contents of `ch_input`.
+
+* Execute the pipeline. Do you see what you expect? Remove the `.view()`
+  operator before moving on.
+
+> **Note** <br>
+> While we are still hard-coding the name of the samplesheet it is still much
+> better to edit a samplesheet than having to edit the pipeline itself - there
+> are also convenient ways to work around this using *parameters*, which we'll
+> talk more about later in this tutorial.
+
+We can also specify a header in our samplesheet like so: `.splitCsv(header:
+true)`.
+
+* Add an appropriate header to your samplesheet, make sure your workflow can
+  read it and execute. Use `.view()` to see what's going on, if needed.
+
 # Adding more processes
 
 It's time to add more processes to our workflow! We have the two files
@@ -244,7 +302,8 @@ call this process `CONCATENATE_FILES` and it will take the output from
 `CONVERT_TO_UPPER_CASE` as input, grouped using the `collect()` operator.
 
 * Add a line to your workflow definition for this new process with the
-  appropriate input - click below if you're having trouble.
+  appropriate input - remember that you can use `.view()` to check channel
+  contents; click below if you're having trouble.
 
 <details>
 <summary> Click to show </summary>
@@ -254,7 +313,6 @@ CONCATENATE_FILES( CONVERT_TO_UPPER_CASE.out.collect() )
 ```
 
 </details>
-
 
 Now all we have to do is define the actual `CONCATENATE_FILES` process in the
 process definition section.
@@ -278,8 +336,8 @@ process CONCATENATE_FILES {
 }
 ```
 
-Run your workflow again and check the `results/` directory. At this point you
-should have three files there: `a.upper.txt`, `b.upper.txt` and `concat.txt`.
+* Run your workflow again and check the `results/` directory. At this point you
+  should have three files there: `a.upper.txt`, `b.upper.txt` and `concat.txt`.
 
 * Inspect the contents of `concat.txt` - do you see everything as you expected?
 
@@ -289,21 +347,6 @@ references a list. Each file in that list can be individually accessed using an
 index e.g. `${files[0]}`, or as we do here, use the variable without an index
 to list all the input files.
 
-# Viewing channel contents
-
-As our channels become more complicated it is useful to actually check out
-what's inside them: you can do this using the `.view()` operator.
-
-* Add the following to your workflow definition (on a new line) and execute the
-  workflow: `ch_input.view()`. What do you see?
-
-It can be quite useful to inspect channel contents like this when you are
-developing workflows, especially if you are working with tuples, maps and any
-transforming operators in general.
-
-* Check the channel contents of the (1) raw and (2) collected output of the
-  `CONVERT_TO_UPPER_CASE` process. How are they different?
-
 > **Quick recap** <br>
 > In this section we've learnt:
 >
@@ -311,5 +354,5 @@ transforming operators in general.
 > * How to create channels for input data
 > * How to execute workflows
 > * How to explore Nextflow's `work` directory
-> * How to generalize workflows
 > * How to view channel contents
+> * How to use samplesheets as input

--- a/pages/nextflow/nextflow-3-executing-workflows.md
+++ b/pages/nextflow/nextflow-3-executing-workflows.md
@@ -8,15 +8,17 @@ workflow {
 
     // Workflow for generating count data for the MRSA case study
 
-    // Define SRA input data channel
-    ch_sra_ids = Channel.fromList( ["SRR935090", "SRR935091", "SRR935092"] )
+    // Get input files from a samplesheet
+    ch_input = Channel
+        .fromPath ( "samplesheet.csv" )
+        .splitCsv ( header: true)
 
     // Define the workflow
-    GET_SRA_BY_ACCESSION (
-        ch_sra_ids
+    DOWNLOAD_FASTQ_FILES (
+        ch_input
     )
     RUN_FASTQC (
-        GET_SRA_BY_ACCESSION.out
+        DOWNLOAD_FASTQ_FILES.out
     )
     RUN_MULTIQC (
         RUN_FASTQC.out[1].collect()
@@ -26,7 +28,7 @@ workflow {
         GET_GENOME_FASTA.out.fasta
     )
     ALIGN_TO_GENOME (
-        GET_SRA_BY_ACCESSION.out,
+        DOWNLOAD_FASTQ_FILES.out,
         INDEX_GENOME.out.index
     )
     SORT_BAM (
@@ -40,13 +42,13 @@ workflow {
 }
 ```
 
-The workflow has one input channel named `ch_sra_ids`, which is a list of SRA
-IDs (*i.e.* a list of strings). We then define the processes to be executed by
-this workflow, nine in total. The first process (`GET_SRA_BY_ACCESSION`) takes
-the `ch_sra_ids` channel as input, while the rest of the processes takes the
-output of previous processes as input. Before we go into more detail regarding
-the ins-and-outs of this workflow, let's start with some specifics of how
-workflows are executed and what you can get from them.
+The workflow has one input channel named `ch_input`, which reads input from the
+`samplesheet.csv` file. We then define the processes to be executed by this
+workflow, nine in total. The first process (`GET_SRA_BY_ACCESSION`) takes the
+`ch_input` channel as input, while the rest of the processes takes the output of
+previous processes as input. Before we go into more detail regarding the
+ins-and-outs of this workflow, let's start with some specifics of how workflows
+are executed and what you can get from them.
 
 # Reports and visualisations
 

--- a/pages/nextflow/nextflow-4-working-with-processes.md
+++ b/pages/nextflow/nextflow-4-working-with-processes.md
@@ -12,7 +12,7 @@ which should look something like this:
 N E X T F L O W  ~  version 21.04.0
 Launching `./main.nf` [friendly_bhaskara] - revision: b4490b9201
 executor >  local (17)
-[c9/e5f818] process > GET_SRA_BY_ACCESSION (SRR935092) [100%] 3 of 3 ✔
+[c9/e5f818] process > DONWLOAD_FASTQ_FILES (SRR935092) [100%] 3 of 3 ✔
 [d5/b5f24e] process > RUN_FASTQC (SRR935092)           [100%] 3 of 3 ✔
 [91/2cea54] process > RUN_MULTIQC                      [100%] 1 of 1 ✔
 [e0/b4fd37] process > GET_GENOME_FASTA                 [100%] 1 of 1 ✔
@@ -27,34 +27,26 @@ Have you noticed that there are SRA IDs after some of the processes? Well, if
 you look at which processes show these SRA IDs you might see that it's only
 those processes that are executed three times, *i.e.* once per SRA ID. This
 doesn't happen automatically, however, and comes from something called *tags*.
-Let's look at the `GET_SRA_BY_ACCESSION` process:
+Let's look at the `DONWLOAD_FASTQ_FILES` process:
 
 ```nextflow
-process GET_SRA_BY_ACCESSION {
+process DONWLOAD_FASTQ_FILES {
 
-    // Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run
-    // accession number.
+    // Download a single-read FASTQ file from the SciLifeLab Figshare remote
 
     tag "${sra_id}"
     publishDir "results/data/raw_internal",
         mode: "copy"
 
     input:
-    val(sra_id)
+    tuple val(sra_id), val(figshare_link)
 
     output:
     tuple val(sra_id), path("*.fastq.gz")
 
     script:
     """
-    fastq-dump ${sra_id} \
-        -X 25000 \
-        --readids \
-        --dumpbase \
-        --skip-technical \
-        --gzip \
-        -Z \
-        > ${sra_id}.fastq.gz
+    wget ${figshare_link} -O ${sra_id}.fastq.gz
     """
 }
 ```
@@ -66,7 +58,7 @@ sample is being processed) but also for debugging or finding problematic samples
 in case of errors or odd output. There is, naturally, no need to use tags for
 processes which are only run once.
 
-* Comment out (prefix with `//`) the `tag` directive from the `GET_SRA_BY_ACCESSION` process and run the
+* Comment out (prefix with `//`) the `tag` directive from the `DONWLOAD_FASTQ_FILES` process and run the
   workflow again. No more SRA IDs!
 
 * Uncomment the `tag` directive before you move on.
@@ -92,7 +84,6 @@ process RUN_FASTQC {
 
     script:
     """
-    # Run FastQC
     fastqc ${fastq} -q
     """
 }

--- a/pages/nextflow/nextflow-5-workflow-configuration.md
+++ b/pages/nextflow/nextflow-5-workflow-configuration.md
@@ -4,7 +4,7 @@ project that is purely aimed at getting reproducible results (which is the full
 extent of what you want in a lot of cases), but it can be made a lot more
 generalisable. Let's go through the MRSA workflow and see what can be improved!
 
-# Configuration basics
+# Parameters
 
 One of the things that allow generalisability of Nextflow workflows is
 *parameters*, which hold information and values that can be changed directly on
@@ -22,10 +22,10 @@ params {
 
 You would then refer to these parameters using *e.g.* `params.parameter_1`
 anywhere you need to in the workflow. Although parameters can be defined in
-`main_mrsa.nf`, it is preferable to define them in a separate *configuration file*. The default name
-of this file is `nextflow.config` and if such a file is present it will be used
-automatically by Nextflow (to supply a config file with another name use
-`nextflow -c <path-to-config-file> run main_mrsa.nf`)
+`main_mrsa.nf`, it is preferable to define them in a separate *configuration
+file*. The default name of this file is `nextflow.config` and if such a file is
+present it will be used automatically by Nextflow (to supply a config file with
+another name use `nextflow -c <path-to-config-file> run main_mrsa.nf`)
 
 * Create a configuration file and add a parameter for the `results` output
   directory.
@@ -43,10 +43,11 @@ automatically by Nextflow (to supply a config file with another name use
 
 # Command line parameters
 
-Workflow parameters can be assigned on the command-line by executing workflows like 
-so: `nextflow run main_mrsa.nf --parameter_name 'some_value'`. The workflow parameter `parameter_name`,
-is prefixed by a double dash `--` to tell Nextflow this is a parameter to the workflow (a single dash
-is a parameter to Nextflow, e.g. `-resume`). The value is also quoted (this is important for parameters
+Workflow parameters can be assigned on the command-line by executing workflows
+like so: `nextflow run main_mrsa.nf --parameter_name 'some_value'`. The workflow
+parameter `parameter_name` is prefixed by a double dash `--` to tell Nextflow
+this is a parameter to the workflow (a single dash is a parameter to Nextflow,
+*e.g.* `-resume`). The value is also quoted (this is important for parameters
 that take file paths as values).
 
 * Run your workflow using the parameter you previously created, but pick
@@ -54,50 +55,20 @@ that take file paths as values).
 
 You should now have a new directory containing all the results! This is highly
 useful if you want to keep track of separate runs of a workflow with different
-software parameters, for example: `nextflow run main.nf --important_param 'value1'
---resultsdir 'value1'`, or simply want to keep the results of separate versions of
-the same workflow. You can also change parameters by using the `-params-file` option
-or by using another configuration file (and using `-c`), rather than on the command line!
+software parameters, for example: `nextflow run main.nf --important_param
+'value1' --resultsdir 'results-value1'`, or simply want to keep the results of
+separate versions of the same workflow. You can also change parameters by using
+the `-params-file` option or by using another configuration file (and using
+`-c`), rather than on the command line!
 
 # Configuring inputs
 
-Remember the input for the MRSA workflow, the `ch_sra_ids` channel? This input
-is also hard-coded inside the `main_mrsa.nf` file. This could also be made into
-a parameter!
+Remember the input for the MRSA workflow, the `ch_input` channel? This input
+(the `samplesheet.csv` file) is hard-coded inside the `main_mrsa.nf` file. This
+could also be made into a parameter!
 
-* Add another parameter for the input SRA IDs and execute your workflow to check
-  that it worked.
-
-Using lists for parameters has its problems though, as you won't be able to
-change it on the command line, since the command line doesn't know about Groovy
-lists. There are several other ways of specifying inputs in a command
-line-friendly way, one of which is to use *sample sheets*. Instead of
-specifying samples directly in the command line, you specify a file that lists
-the input samples instead; this is the standard that is used in *e.g.* [nf-core
-pipelines](https://nf-co.re/). Such a sample sheet for the MRSA workflow might
-be stored in *e.g.* `input.csv` and look like this:
-
-```no-highlight
-sra_id
-SRR935090
-SRR935091
-SRR935092
-```
-
-Reading input from a CSV file can be done by combining the `.splitCsv` channel
-factory (splitting the rows to read each entry) and the `.map` operator
-(defining which columns should be used). Let's see if we can make it work!
-
-* Create the `input.csv` file with the above shown content.
-
-* Change the definition of the `ch_sra_ids` channel to take the value of a new
+* Change the definition of the `ch_input` channel to take the value of a new
   parameter of your choice, defined in the configuration file.
-
-* Add the `.splitCsv(header: true)` operator to the end of the channel
-  definition, so that the input is read from the file contents.
-
-* Add the `.map{row -> row.sra_id}` operator, which specifies that each row
-  should contain the `sra_id` column, but no other columns.
 
 You should now have a more generalised input to your workflow! Try to run it to
 make sure it works - look below if you need some help.
@@ -107,48 +78,21 @@ make sure it works - look below if you need some help.
 
 ```nextflow
 // Channel definition
-ch_sra_ids = Channel
-    .fromPath ( params.sra_ids )
+ch_input = Channel
+    .fromPath ( params.input )
     .splitCsv ( header: true )
-    .map      { row -> row.sra_id }
 
 // Configuration file
-sra_ids = "input.csv"
+input = "samplesheet.csv"
 ```
 
 </details>
 
-By specifying inputs from sample sheets like this we can change inputs
-of a workflow execution by creating another sample sheet and specifying
-*e.g.*, `--sra_ids input-2.csv` on the command line. This is highly useful when
-you want to run a single sample *e.g.*, when testing a workflow, or when you
-want to keep track of all the different inputs you've used historically. Sample
-sheets are also useful for keeping other metadata, such as custom sample names,
-sample groups, location of files, *etc.* For example:
-
-```no-hightlight
-sample-1,case,data/sample-1.fastq.gz
-sample-2,ctrl,data/sample-2.fastq.gz
-sample-3,case,data/sample-3.fastq.gz
-sample-4,ctrl,data/sample-4.fastq.gz
-```
-
-Here we have not only names and file paths but also to which group each sample
-belongs, *i.e.* case or control. Such metadata can be highly useful for more
-advanced workflows to use in downstream analyses, such as differential gene
-expression! We could create a tuple based on this metadata like so:
-
-```nextflow
-ch_input = Channel
-    .fromPath("metadata.csv")
-    .splitCsv(header: ['id', 'group', 'fastq'])
-    .view()
-```
-
-> **Input file formatting** <br>
-> The input file may also have headers, in which case you can use `header:
-> true` to use the column headers defined in the file. You can also read *e.g.*
-> tab-separated files by using the `sep` field: `.splitCsv(sep: "\t")`.
+By specifying inputs from sample sheets like this we can change inputs of a
+workflow execution by creating another sample sheet and specifying *e.g.*,
+`--input input-2.csv` on the command line. This is highly useful when you want
+to run a single sample *e.g.*, when testing a workflow, or when you want to keep
+track of all the different inputs you've used historically.
 
 # Other configuration scopes
 

--- a/pages/nextflow/nextflow-7-extra-material.md
+++ b/pages/nextflow/nextflow-7-extra-material.md
@@ -147,10 +147,9 @@ high-throughput sequencing is that you have pairs of reads for each sample.
 Nextflow has a special, built-in way to create channels for this data type: the
 `fromFilePairs` channel factory:
 
-```groovy
-Channel
+```nextflow
+ch_raw_reads = Channel
     .fromFilePairs ( "data/*_R{1,2}.fastq.gz" )
-    .set           { ch_raw_reads }
 ```
 
 This will create a channel containing all the reads in the `data/` directory in
@@ -172,27 +171,26 @@ simple. For more methods of reading in data see the Nextflow documentation on
 We can also do quite advanced things to manipuate data in channels, such as this:
 
 ```groovy
-Channel
+samples_and_treatments = Channel
     .fromPath ( params.metadata )
     .splitCsv ( sep: "\t", header: true )
     .map      { row -> tuple("${row.sample_id}", "${row.treatment}") }
     .filter   { id, treatment -> treatment != "DMSO" }
     .unique   (  )
-    .set      { samples_and_treatments }
 ```
 
 That's a bit of a handful! But what does it do? The first line specifies that we
 want to read some data from a file specified by the `metadata` parameter, and
 the second line actually reads that data using tab as delimiter, including a
 header. The `map` operator takes each entire row and subsets it to only two
-columns: the `sample_id` and `treatment` columns. This subset is stored as a
-tuple. The `filter` operator is then used to remove any tuples where the second
-entry, `treatment`, is not equal to the string `"DMSO"` (*i.e.* untreated cells, in this example).
-We then only take the unique tuples and set the results as the new channel
-`samples_and_treatments`. Let's say that this is the metadata we're reading:
+columns: the `sample_id` and `treatment` columns (discarding the other columns).
+This subset is stored as a tuple. The `filter` operator is then used to remove
+any tuples where the second entry (`treatment`) is not equal to the string
+`"DMSO"` (*i.e.* untreated cells, in this example). Finally, we only keep unique
+tuple values. Let's say that this is the metadata we're reading:
 
 ```no-highlight
-sample_id     dose    group     treatment
+sample        dose    group     treatment
 sample_1      0.1     control   DMSO
 sample_1      1.0     control   DMSO
 sample_1      2.0     control   DMSO

--- a/pages/snakemake/snakemake-4-the-mrsa-workflow.md
+++ b/pages/snakemake/snakemake-4-the-mrsa-workflow.md
@@ -49,12 +49,16 @@ are unfamiliar with the purpose of the different operations (index genome,
 FastQC and so on), then take a look at the [intro](introduction).
 
 Also generate the job graph in the same manner. Here you can see that three
-samples will be downloaded from SRA (Sequence Read Archive); SRR935090,
-SRR935091, and SRR935092. Those will then be quality controlled with FastQC and
-aligned to a genome. The QC output will be aggregated with MultiQC and the
-alignments will be used to generate a count table, *i.e.* a table that shows
-how many reads map to each gene for each sample. This count table is then what
-the downstream analysis will be based on.
+samples will be downloaded: SRR935090, SRR935091, and SRR935092. The 
+original sample files contain tens of millions of reads but for the purpose 
+of this course we have subsampled them to 100,000 reads per sample, so that 
+they are easy to manage, and made them available at the [SciLifeLab Data 
+Repository](https://figshare.scilifelab.se/articles/educational_resource/MRSA_case_study_example_data/22246417).
+These fastq files will then be quality controlled with FastQC and aligned to 
+a genome. The QC output will be aggregated with MultiQC and the alignments 
+will be used to generate a count table, *i.e.* a table that shows how many 
+reads map to each gene for each sample. This count table is then what the 
+downstream analysis will be based on.
 
 ![](images/dag_mrsa.svg)
 

--- a/pages/snakemake/snakemake-5-parameters.md
+++ b/pages/snakemake/snakemake-5-parameters.md
@@ -18,10 +18,56 @@ rule some_rule:
         """
 ```
 
-We run most of the programs with default settings in our workflow. However,
-there is one parameter in the rule `get_SRA_by_accession` that we use for
-determining how many reads we want to retrieve from SRA for each sample 
-(`-X 25000`). Change in this rule to use the parameter `max_reads` instead and 
+Most of the programs are run with default settings in the MRSA workflow and 
+don't use the `params:` directive. However, the `get_SRA_by_accession` rule 
+is an exception. Here the remote address for each of the files to download 
+is passed to the shell directive via:
+
+```python
+def get_sample_url(wildcards):
+    samples = {
+        "SRR935090": "https://figshare.scilifelab.se/ndownloader/files/39539767",
+        "SRR935091": "https://figshare.scilifelab.se/ndownloader/files/39539770",
+        "SRR935092": "https://figshare.scilifelab.se/ndownloader/files/39539773"
+    }
+    return samples[wildcards.sample_id]
+    
+rule get_SRA_by_accession:
+    """
+    Retrieve a single-read FASTQ file
+    """
+    output:
+        "data/raw_internal/{sample_id}.fastq.gz"
+    params:
+        url = get_sample_url
+    shell:
+        """
+        curl -L {params.url} | seqtk sample - 25000 | gzip -c > {output[0]}
+        """
+
+```
+
+You may recognize this from [page 2](snakemake-2-the-basics.md) of this 
+tutorial where we used input functions to generate strings and lists of 
+strings for the `input:` section of a rule. Using a function to return 
+values based on the wildcards also works for `params:`. Here `sample_id` is 
+a wildcard which in this specific workflow can be either `SRR935090`, 
+`SRR935091`, or `SRR935092`. The wildcards object is passed to the function 
+`get_sample_url` and depending on what output the rule is supposed to 
+generate, `wildcards.sample_id` will take the value of either of the three 
+sample ids. The `samples` variable defined in the function is a Python 
+[dictionary](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
+that has the URLs for each sample_id hardcoded. This dictionary is used to 
+convert the value of the `sample_id` wildcard to a URL, which is returned by 
+the function. Finally, in the `shell:` directive we access the `url` parameter 
+with `{params.url}`. (We could have written three separate rules to download 
+the samples, but it's easy to see how that can become impractical.)
+
+Let's add another parameter to the `get_SRA_by_accession` rule. As you can 
+see in the shell command the fastq file downloaded by `curl` gets piped 
+directly to the `seqtk sample` command which reads from STDIN and outputs 
+25000 randomly sampled reads (out of the 100,000 contained in the example fastq 
+file). Change in the rule to use the parameter `max_reads` instead and 
 set the value to 20000. If you need help, click to show the solution below.
 
 <details>
@@ -31,16 +77,16 @@ set the value to 20000. If you need help, click to show the solution below.
 ```python
 rule get_SRA_by_accession:
     """
-    Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run accession number.
+    Retrieve a single-read FASTQ file
     """
     output:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
+        url = get_sample_url,
         max_reads = 20000
     shell:
         """
-        fastq-dump {wildcards.sample_id} -X {params.max_reads} --readids \
-            --dumpbase --skip-technical --gzip -Z > {output}
+        curl -L {params.url} | seqtk sample - {params.max_reads} | gzip -c > {output[0]}
         """
 ```
 
@@ -50,25 +96,25 @@ Now run through the workflow. Because there's been changes to the `get_SRA_by_ac
 rule this will trigger a re-run of the rule for all three accessions. In addition
 all downstream rules that depend on output from `get_SRA_by_accession` are re-run. 
 
-The parameter values we set in the `params` section don't have to be static,
-they can be any Python expression. In particular, Snakemake provides a global
-dictionary of configuration parameters called `config`. Let's modify
-`get_SRA_by_accession` to look something like this in order to make use of this 
-dictionary:
+As you can see the parameter values we set in the `params` section don't have 
+to be static, they can be any Python expression. In particular, Snakemake 
+provides a global dictionary of configuration parameters called `config`. 
+Let's modify `get_SRA_by_accession` to look something like this in order to 
+make use of this dictionary:
 
 ```python
 rule get_SRA_by_accession:
     """
-    Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run accession number.
+    Retrieve a single-read FASTQ file
     """
     output:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
+        url = get_sample_url,
         max_reads = config["max_reads"]
     shell:
         """
-        fastq-dump {wildcards.sample_id} -X {params.max_reads} --readids \
-            --dumpbase --skip-technical --gzip -Z > {output}
+        curl -L {params.url} | seqtk sample - {params.max_reads} | gzip -c > {output[0]}
         """
 ```
 
@@ -77,7 +123,8 @@ dictionary. If we don't populate the dictionary somehow the dictionary will be
 empty so if you were to run the workflow now it would trigger a `KeyError` (try 
 running `snakemake -s snakefile_mrsa.smk -n` to see for yourself). 
 In order to populate the config dictionary with data for the workflow we could 
-use the `snakemake --config KEY=VALUE` syntax directly from the command line.
+use the `snakemake --config KEY=VALUE` syntax directly from the command line 
+(_e.g._ `snakemake --config max_reads=20000 -s snakefile_mrsa.smk`).
 However, from a reproducibility perspective, it's not optimal to set parameters 
 from the command line, since it's difficult to keep track of which parameter 
 values that were used. 

--- a/pages/snakemake/snakemake-8-targets.md
+++ b/pages/snakemake/snakemake-8-targets.md
@@ -1,8 +1,8 @@
-So far we have only defined the inputs/outputs of a rule as strings, or in
-some case a list of strings, but Snakemake allows us to be much more flexible
-than that. Actually, we can use any Python expression or even functions, as
-long as they return a string or list of strings. Consider the rule
-`align_to_genome` below.
+We've mentioned that Snakemake rules take either strings or a list of strings as
+input, and that we can use any Python expression in Snakemake workflows. 
+Here we'll show how these features help us condense the code of rules.
+
+Consider the rule `align_to_genome` below.
 
 ```python
 rule align_to_genome:
@@ -10,7 +10,7 @@ rule align_to_genome:
     Align a fastq file to a genome index using Bowtie 2.
     """
     output:
-        "intermediate/{sample_id,\w+}.bam"
+        "intermediate/{sample_id}.bam"
     input:
         "data/raw_internal/{sample_id}.fastq.gz",
         "intermediate/NCTC8325.1.bt2",
@@ -26,9 +26,10 @@ rule align_to_genome:
 ```
 
 Here we have seven inputs; the fastq file with the reads and six files with
-similar file names from the Bowtie 2 genome indexing. We can try to tidy this
-up by using a Python expression to generate a list of these files instead. If
-you're familiar with Python you could do this with 
+similar file names from the Bowtie 2 genome indexing. Instead of writing all 
+the filenames we can tidy this up by using a Python expression to generate a 
+list of these files instead. If you're familiar with Python you could do 
+this with 
 [list comprehensions](https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions)
 like this:
 
@@ -51,16 +52,47 @@ input:
            substr = ["1", "2", "3", "4", "rev.1", "rev.2"])
 ```
 
-Now change in the rules `index_genome` and `align_to_genome` to use the
+**Importantly**, when using expand() like this `substr` is not a wildcard 
+because it is resolved to the values explicitly given inside the expand 
+expression.
+
+Now change in the rules `index_genome` and `align_to_genome` to also use the
 `expand()` expression.
 
 In the workflow we decide which samples to run by including the SRR ids in the
-names of the inputs to the rules `multiqc` and `generate_count_table`. This is
-a potential source of errors since it's easy to change in one place and forget
-to change in the other. As we've mentioned before, but not really used so far,
-Snakemake allows us to use Python code "everywhere". Let's therefore define
-a list of sample ids and put at the very top of the Snakefile, just before the
-rule `all`.
+names of the inputs to the rules `multiqc` and `generate_count_table`:
+
+```python
+rule generate_count_table:
+    output:
+        "results/tables/counts.tsv"
+    input:
+        bams = ["intermediate/SRR935090.sorted.bam", 
+                "intermediate/SRR935091.sorted.bam", 
+                "intermediate/SRR935092.sorted.bam"],
+...
+rule multiqc:
+    output:
+        html = "results/multiqc.html",
+        stats = "intermediate/multiqc_general_stats.txt"
+    input:
+        "intermediate/SRR935090_fastqc.zip",
+        "intermediate/SRR935091_fastqc.zip",
+        "intermediate/SRR935092_fastqc.zip"
+
+```
+
+The output files from these two rules, `results/multiqc.html` and  
+`results/tables/counts.tsv`, are in turn specified as input to the `all` rule
+at the top of the file. Because the first rule is targeted by default when 
+we run Snakemake on the command line (like we mentioned in 
+[snakemake-4-the-mrsa-workflow](snakemake-4-the-mrsa-workflow.md)) this 
+is what triggers the rules to run on each of the three samples.
+
+However, this is a potential source of errors since it's easy to change in one 
+place and forget to change in the other. Because we can use Python code 
+"everywhere" let's instead define a list of sample ids and put at the very 
+top of the Snakefile, just before the rule `all`:
 
 ```python
 SAMPLES = ["SRR935090", "SRR935091", "SRR935092"]

--- a/tutorials/conda/code/run_qc.sh
+++ b/tutorials/conda/code/run_qc.sh
@@ -4,9 +4,9 @@ mkdir -p intermediate/fastqc
 mkdir -p results/fastqc
 
 # Define URLs to fastq files for each sample
-SRR935090=""
-SRR935091=""
-SRR935092=""
+SRR935090="https://figshare.scilifelab.se/ndownloader/files/39539767"
+SRR935091="https://figshare.scilifelab.se/ndownloader/files/39539770"
+SRR935092="https://figshare.scilifelab.se/ndownloader/files/39539773"
 
 # Download fastq files from remote repository and put in data/raw_internal/:
 curl -L  "$SRR935090" -o data/raw_internal/SRR935090.fastq.gz

--- a/tutorials/conda/code/run_qc.sh
+++ b/tutorials/conda/code/run_qc.sh
@@ -3,10 +3,15 @@ mkdir -p data/raw_internal
 mkdir -p intermediate/fastqc
 mkdir -p results/fastqc
 
-# Download fastq files using sra-tools and put in data/raw_internal/:
-fastq-dump SRR935090 -X 12000 --gzip -Z > data/raw_internal/SRR935090.fastq.gz
-fastq-dump SRR935091 -X 12000 --gzip -Z > data/raw_internal/SRR935091.fastq.gz
-fastq-dump SRR935092 -X 12000 --gzip -Z > data/raw_internal/SRR935092.fastq.gz
+# Define URLs to fastq files for each sample
+SRR935090=""
+SRR935091=""
+SRR935092=""
+
+# Download fastq files from remote repository and put in data/raw_internal/:
+curl -L  "$SRR935090" -o data/raw_internal/SRR935090.fastq.gz
+curl -L  "$SRR935091" -o data/raw_internal/SRR935091.fastq.gz
+curl -L  "$SRR935092" -o data/raw_internal/SRR935092.fastq.gz
 
 # Run fastqc, put output zip in intermediate/fastq/ and html in results/fastqc:
 fastqc  data/raw_internal/SRR935090.fastq.gz --outdir=intermediate/fastqc/

--- a/tutorials/containers/Dockerfile
+++ b/tutorials/containers/Dockerfile
@@ -50,11 +50,6 @@ RUN conda config --add channels bioconda \
     && mamba install -c conda-forge jupyter \
     && conda clean --all
 
-# Install sra-tools
-RUN curl --output sratoolkit.tar.gz https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/current/sratoolkit.current-ubuntu64.tar.gz \
-    && mkdir tmp_out && tar --wildcards -C tmp_out -zxvf sratoolkit.tar.gz */bin/* && cp -r tmp_out/*/bin/* $CONDA_PREFIX/bin/ \
-    && rm -r sratoolkit.tar.gz tmp_out/
-
 # Open port for running Jupyter Notebook
 EXPOSE 8888
 

--- a/tutorials/containers/Snakefile
+++ b/tutorials/containers/Snakefile
@@ -32,7 +32,7 @@ rule get_SRA_by_accession:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
         max_reads = config["max_reads"],
-        url = config["{sample_id}"]
+        url = lambda wildcards: config[wildcards.sample_id]
     version: "1.0"
     shell:
         """

--- a/tutorials/containers/Snakefile
+++ b/tutorials/containers/Snakefile
@@ -15,19 +15,28 @@ rule all:
 
 rule get_SRA_by_accession:
     """
-    Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run accession number.
+    Retrieve a single-read FASTQ file from a remote repository
+    
+    The fastq file is retrieved with curl is piped directly to the 
+    seqtk program which samples a number of reads defined by the 
+    max_reads parameter. The fastq output from seqtk is in turn piped 
+    to gzip and stored as a compressed *.fastq.gz file.
 
-    max_reads: Maximal number of reads to download for each sample.
+    The actual URL for the file is obtained from the config which 
+    requires that each sample_id is defined in the configfile as for 
+    example:
+    
+    sample_id: "https://url/to/file"
     """
     output:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
-        max_reads = config["max_reads"]
+        max_reads = config["max_reads"],
+        url = config["{sample_id}"]
     version: "1.0"
     shell:
         """
-        fastq-dump {wildcards.sample_id} -X {params.max_reads} --readids \
-            --dumpbase --skip-technical --gzip -Z > {output}
+        curl -L {params.url} | seqtk sample - {params.max_reads} | gzip -c > {output[0]}
         """
 
 rule fastqc:

--- a/tutorials/containers/config.yml
+++ b/tutorials/containers/config.yml
@@ -3,6 +3,11 @@ sample_ids: ["SRR935090","SRR935091","SRR935092"]
 sample_ids_geo: ["GSM1186459", "GSM1186460", "GSM1186461"]
 series_id_geo: "GSE48896"
 
+# URLs to gzipped fastq files for each sample in remote repository
+SRR935090: ""
+SRR935091: ""
+SRR935092: ""
+
 # Maximal number of reads to retrieve for each run. This is to reduce the time
 # and space needed for this tutorial. Use a very large number, such as 100000000,
 # if you want to use the full files.

--- a/tutorials/containers/config.yml
+++ b/tutorials/containers/config.yml
@@ -4,13 +4,14 @@ sample_ids_geo: ["GSM1186459", "GSM1186460", "GSM1186461"]
 series_id_geo: "GSE48896"
 
 # URLs to gzipped fastq files for each sample in remote repository
-SRR935090: ""
-SRR935091: ""
-SRR935092: ""
+SRR935090: "https://figshare.scilifelab.se/ndownloader/files/39539767"
+SRR935091: "https://figshare.scilifelab.se/ndownloader/files/39539770"
+SRR935092: "https://figshare.scilifelab.se/ndownloader/files/39539773"
 
 # Maximal number of reads to retrieve for each run. This is to reduce the time
-# and space needed for this tutorial. Use a very large number, such as 100000000,
-# if you want to use the full files.
+# and space needed for this tutorial. The maximum number of reads is 100000
+# which is the total number of reads available in the subsampled files we
+# are using for this course
 max_reads: 25000
 
 # Genome id to align to. Should match with an entry in "genomes" below.

--- a/tutorials/containers/environment.yml
+++ b/tutorials/containers/environment.yml
@@ -1,20 +1,20 @@
 channels:
   - conda-forge
   - bioconda
-  - main
   - r
 dependencies:
-  - python=3.9.12
-  - fastqc=0.11.9
-  - snakemake=7.18.2
-  - multiqc=1.12
-  - bowtie2=2.4.5
-  - tbb=2020.2
-  - samtools=1.15.1
-  - subread=2.0.1
-  - bedtools=2.29.2
+  - python=3.10.9
+  - fastqc=0.12.1
+  - seqtk=1.3
+  - snakemake=7.24.0
+  - multiqc=1.14
+  - bowtie2=2.5.1
+  - tbb=2021.8.0
+  - samtools=1.16.1
+  - subread=2.0.3
+  - bedtools2.30.0
   - wget=1.20.3
-  - graphviz=3.0.0
+  - graphviz=7.0.5
   - r-base=4.1.3
   - r-ggplot2=3.3.5
   - r-reshape2=1.4.4

--- a/tutorials/containers/run_qc.sh
+++ b/tutorials/containers/run_qc.sh
@@ -3,10 +3,15 @@ mkdir -p data/raw_internal
 mkdir -p intermediate/fastqc
 mkdir -p results/fastqc
 
-# Download fastq files using sra-tools and put in data/raw_internal/:
-fastq-dump SRR935090 -X 15000 --gzip -Z > data/raw_internal/SRR935090.fastq.gz
-fastq-dump SRR935091 -X 15000 --gzip -Z > data/raw_internal/SRR935091.fastq.gz
-fastq-dump SRR935092 -X 15000 --gzip -Z > data/raw_internal/SRR935092.fastq.gz
+# Define URLs to fastq files for each sample
+SRR935090=""
+SRR935091=""
+SRR935092=""
+
+# Download fastq files from remote repository and put in data/raw_internal/:
+curl -L  "$SRR935090" -o data/raw_internal/SRR935090.fastq.gz
+curl -L  "$SRR935091" -o data/raw_internal/SRR935091.fastq.gz
+curl -L  "$SRR935092" -o data/raw_internal/SRR935092.fastq.gz
 
 # Run fastqc, put output zip in intermediate/fastq/ and html in results/fastqc:
 fastqc  data/raw_internal/SRR935090.fastq.gz --outdir=intermediate/fastqc/

--- a/tutorials/containers/run_qc.sh
+++ b/tutorials/containers/run_qc.sh
@@ -4,9 +4,9 @@ mkdir -p intermediate/fastqc
 mkdir -p results/fastqc
 
 # Define URLs to fastq files for each sample
-SRR935090=""
-SRR935091=""
-SRR935092=""
+SRR935090="https://figshare.scilifelab.se/ndownloader/files/39539767"
+SRR935091="https://figshare.scilifelab.se/ndownloader/files/39539770"
+SRR935092="https://figshare.scilifelab.se/ndownloader/files/39539773"
 
 # Download fastq files from remote repository and put in data/raw_internal/:
 curl -L  "$SRR935090" -o data/raw_internal/SRR935090.fastq.gz

--- a/tutorials/git/Snakefile
+++ b/tutorials/git/Snakefile
@@ -32,7 +32,7 @@ rule get_SRA_by_accession:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
         max_reads = config["max_reads"],
-        url = config["{sample_id}"]
+        url = lambda wildcards: config[wildcards.sample_id]
     version: "1.0"
     shell:
         """

--- a/tutorials/git/Snakefile
+++ b/tutorials/git/Snakefile
@@ -15,19 +15,28 @@ rule all:
 
 rule get_SRA_by_accession:
     """
-    Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run accession number.
+    Retrieve a single-read FASTQ file from a remote repository
+    
+    The fastq file is retrieved with curl is piped directly to the 
+    seqtk program which samples a number of reads defined by the 
+    max_reads parameter. The fastq output from seqtk is in turn piped 
+    to gzip and stored as a compressed *.fastq.gz file.
 
-    max_reads: Maximal number of reads to download for each sample.
+    The actual URL for the file is obtained from the config which 
+    requires that each sample_id is defined in the configfile as for 
+    example:
+    
+    sample_id: "https://url/to/file"
     """
     output:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
-        max_reads = config["max_reads"]
+        max_reads = config["max_reads"],
+        url = config["{sample_id}"]
     version: "1.0"
     shell:
         """
-        fastq-dump {wildcards.sample_id} -X {params.max_reads} --readids \
-            --dumpbase --skip-technical --gzip -Z > {output}
+        curl -L {params.url} | seqtk sample - {params.max_reads} | gzip -c > {output[0]}
         """
 
 rule fastqc:

--- a/tutorials/git/config.yml
+++ b/tutorials/git/config.yml
@@ -3,6 +3,11 @@ sample_ids: ["SRR935090","SRR935091","SRR935092"]
 sample_ids_geo: ["GSM1186459", "GSM1186460", "GSM1186461"]
 series_id_geo: "GSE48896"
 
+# URLs to gzipped fastq files for each sample in remote repository
+SRR935090: ""
+SRR935091: ""
+SRR935092: ""
+
 # Maximal number of reads to retrieve for each run. This is to reduce the time
 # and space needed for this tutorial. Use a very large number, such as 100000000,
 # if you want to use the full files.

--- a/tutorials/git/environment.yml
+++ b/tutorials/git/environment.yml
@@ -2,20 +2,20 @@ name: git-env
 channels:
   - conda-forge
   - bioconda
-  - main
   - r
 dependencies:
-  - python=3.9.12
-  - fastqc=0.11.9
-  - snakemake=7.18.2
-  - multiqc=1.12
-  - bowtie2=2.4.5
-  - tbb=2020.2
-  - samtools=1.15.1
-  - subread=2.0.1
-  - bedtools=2.29.2
+  - python=3.10.9
+  - fastqc=0.12.1
+  - seqtk=1.3
+  - snakemake=7.24.0
+  - multiqc=1.14
+  - bowtie2=2.5.1
+  - tbb=2021.8.0
+  - samtools=1.16.1
+  - subread=2.0.3
+  - bedtools2.30.0
   - wget=1.20.3
-  - graphviz=3.0.0
+  - graphviz=7.0.5
   - r-base=4.1.3
   - r-ggplot2=3.3.5
   - r-reshape2=1.4.4

--- a/tutorials/git/environment.yml
+++ b/tutorials/git/environment.yml
@@ -7,7 +7,6 @@ channels:
 dependencies:
   - python=3.9.12
   - fastqc=0.11.9
-  - sra-tools=2.11.0
   - snakemake=7.18.2
   - multiqc=1.12
   - bowtie2=2.4.5

--- a/tutorials/jupyter/Snakefile
+++ b/tutorials/jupyter/Snakefile
@@ -15,19 +15,28 @@ rule all:
 
 rule get_SRA_by_accession:
     """
-    Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run accession number.
+    Retrieve a single-read FASTQ file from a remote repository
+    
+    The fastq file is retrieved with curl is piped directly to the 
+    seqtk program which samples a number of reads defined by the 
+    max_reads parameter. The fastq output from seqtk is in turn piped 
+    to gzip and stored as a compressed *.fastq.gz file.
 
-    max_reads: Maximal number of reads to download for each sample.
+    The actual URL for the file is obtained from the config which 
+    requires that each sample_id is defined in the configfile as for 
+    example:
+    
+    sample_id: "https://url/to/file"
     """
     output:
         "data/raw_internal/{sample_id}.fastq.gz"
     params:
-        max_reads = config["max_reads"]
+        max_reads = config["max_reads"],
+        url = config["{sample_id}"]
     version: "1.0"
     shell:
         """
-        fastq-dump {wildcards.sample_id} -X {params.max_reads} --readids \
-            --dumpbase --skip-technical --gzip -Z > {output}
+        curl -L {params.url} | seqtk sample - {params.max_reads} | gzip -c > {output[0]}
         """
 
 rule fastqc:

--- a/tutorials/jupyter/config.yml
+++ b/tutorials/jupyter/config.yml
@@ -2,6 +2,11 @@
 sample_ids: ["SRR935090","SRR935091","SRR935092"]
 sample_ids_geo: ["GSM1186459", "GSM1186460", "GSM1186461"]
 
+# URLs to gzipped fastq files for each sample in remote repository
+SRR935090: ""
+SRR935091: ""
+SRR935092: ""
+
 # Maximal number of reads to retrieve for each run. This is to reduce the time
 # and space needed for this tutorial. Use a very large number, such as 100000000,
 # if you want to use the full files.

--- a/tutorials/nextflow/environment.yml
+++ b/tutorials/nextflow/environment.yml
@@ -2,14 +2,12 @@ name: nextflow-env
 channels:
   - conda-forge
   - bioconda
-  - r
 dependencies:
+  - bowtie2=2.5.1
   - fastqc=0.11.9
-  - sra-tools=2.11.0
-  - nextflow=21.04.0
-  - multiqc=1.10.1
-  - bowtie2=2.4.4
-  - samtools=1.10
-  - subread=2.0.1
-  - wget=1.20.1
-  - graphviz=2.42.3
+  - graphviz=7.0.5
+  - multiqc=1.14
+  - nextflow=22.10.6
+  - samtools=1.16.1
+  - subread=2.0.3
+  - wget=1.20.3

--- a/tutorials/nextflow/main_mrsa.nf
+++ b/tutorials/nextflow/main_mrsa.nf
@@ -7,15 +7,18 @@ workflow {
 
     // Workflow for generating count data for the MRSA case study
 
-    // Define SRA input data channel
-    ch_sra_ids = Channel.fromList( ["SRR935090", "SRR935091", "SRR935092"] )
+    // Get input files from a samplesheet
+    ch_input = Channel
+        .fromPath ( "samplesheet.csv" )
+        .splitCsv ( header: true)
 
     // Define the workflow
-    GET_SRA_BY_ACCESSION (
-        ch_sra_ids
+    DOWNLOAD_FASTQ_FILES (
+        ch_input
     )
     RUN_FASTQC (
-        GET_SRA_BY_ACCESSION.out
+        DOWNLOAD_FASTQ_FILES.out
+        // ch_input
     )
     RUN_MULTIQC (
         RUN_FASTQC.out[1].collect()
@@ -25,7 +28,8 @@ workflow {
         GET_GENOME_FASTA.out.fasta
     )
     ALIGN_TO_GENOME (
-        GET_SRA_BY_ACCESSION.out,
+        DOWNLOAD_FASTQ_FILES.out,
+        // ch_input,
         INDEX_GENOME.out.index
     )
     SORT_BAM (
@@ -38,31 +42,23 @@ workflow {
     )
 }
 
-process GET_SRA_BY_ACCESSION {
+process DOWNLOAD_FASTQ_FILES {
 
-    // Retrieve a single-read FASTQ file from SRA (Sequence Read Archive) by run
-    // accession number.
+    // Download a single-read FASTQ file from the SciLifeLab Figshare remote
 
     tag "${sra_id}"
     publishDir "results/data/raw_internal",
         mode: "copy"
 
     input:
-    val(sra_id)
+    tuple val(sra_id), val(figshare_link)
 
     output:
     tuple val(sra_id), path("*.fastq.gz")
 
     script:
     """
-    fastq-dump ${sra_id} \
-        -X 25000 \
-        --readids \
-        --dumpbase \
-        --skip-technical \
-        --gzip \
-        -Z \
-        > ${sra_id}.fastq.gz
+    wget ${figshare_link} -O ${sra_id}.fastq.gz
     """
 }
 
@@ -82,7 +78,6 @@ process RUN_FASTQC {
 
     script:
     """
-    # Run FastQC
     fastqc ${fastq} -q
     """
 }

--- a/tutorials/nextflow/main_mrsa.nf
+++ b/tutorials/nextflow/main_mrsa.nf
@@ -18,7 +18,6 @@ workflow {
     )
     RUN_FASTQC (
         DOWNLOAD_FASTQ_FILES.out
-        // ch_input
     )
     RUN_MULTIQC (
         RUN_FASTQC.out[1].collect()
@@ -29,7 +28,6 @@ workflow {
     )
     ALIGN_TO_GENOME (
         DOWNLOAD_FASTQ_FILES.out,
-        // ch_input,
         INDEX_GENOME.out.index
     )
     SORT_BAM (

--- a/tutorials/nextflow/samplesheet.csv
+++ b/tutorials/nextflow/samplesheet.csv
@@ -1,0 +1,4 @@
+sample,file
+SRR935090,https://figshare.scilifelab.se/ndownloader/files/39539767
+SRR935091,https://figshare.scilifelab.se/ndownloader/files/39539770
+SRR935092,https://figshare.scilifelab.se/ndownloader/files/39539773

--- a/tutorials/rmarkdown/environment.yml
+++ b/tutorials/rmarkdown/environment.yml
@@ -3,7 +3,6 @@ channels:
   - r
   - conda-forge
   - bioconda
-  - main
 dependencies:
   - bioconductor-geoquery=2.54.0
   - bioconductor-rtracklayer=1.46.0

--- a/tutorials/snakemake/environment.yml
+++ b/tutorials/snakemake/environment.yml
@@ -6,7 +6,6 @@ channels:
 dependencies:
   - python=3.9.12
   - fastqc=0.11.9
-  - sra-tools=2.11.0
   - snakemake=7.18.2
   - multiqc=1.12
   - bowtie2=2.4.5

--- a/tutorials/snakemake/environment.yml
+++ b/tutorials/snakemake/environment.yml
@@ -2,17 +2,17 @@ name: snakemake-env
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - python=3.9.12
-  - fastqc=0.11.9
-  - snakemake=7.18.2
-  - multiqc=1.12
-  - bowtie2=2.4.5
-  - tbb=2020.2
-  - samtools=1.15.1
-  - subread=2.0.1
-  - graphviz=3.0.0
+  - python=3.10.9
+  - fastqc=0.12.1
+  - seqtk=1.3
+  - snakemake=7.24.0
+  - multiqc=1.14
+  - bowtie2=2.5.1
+  - tbb=2021.8.0
+  - samtools=1.16.1
+  - subread=2.0.3
+  - graphviz=7.0.5
   - wget=1.20.3
   - xorg-libxrender
   - xorg-libxpm


### PR DESCRIPTION
In this PR we remove the dependency on the `sra-tools` package for downloading fastq files. This is because the package is having network errors in some cases when using `fastq-dump`, see for instance:

- https://github.com/ncbi/sra-tools/issues/790
- https://github.com/ncbi/sra-tools/issues/777
- https://github.com/ncbi/sra-tools/issues/788

In order to remove the dependency I uploaded subsampled fastq files to the SciLifeLab Data Repository [here](https://figshare.scilifelab.se/articles/educational_resource/MRSA_case_study_example_data/22246417). These files were created by running `seqtk sample <sample_id>.fastq.gz 100000`.

To make use of these files in the course Snakemake workflow the `get_SRA_by_accesion` rule was updated to:

```python
def get_sample_url(wildcards):
    return config["sample_urls"][wildcards.sample_id]

rule get_SRA_by_accession:
    """
    Retrieve a single-read FASTQ file
    """
    output:
        "data/raw_internal/{sample_id, \w+}.fastq.gz"
    params:
        url = get_sample_url
    shell:
        """
        curl -L {params.url} | seqtk sample - 20000 | gzip -c > {output[0]}
        """
```

This meant introducing the concept of input functions quite early in the tutorial. I think the best thing is actually to introduce input functions already at the start of the tutorial. This change has cascading effects throughout the tutorial.