### PR TITLE
Proposed schedule for VT23

### DIFF
--- a/pages/course-information/schedule.md
+++ b/pages/course-information/schedule.md
@@ -78,22 +78,22 @@
         <td style="padding:5px"> <font size="3"> JS </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 10:15 </td>
+        <td style="padding:5px"> <font size="3"> 10:00 </td>
         <td style="padding:5px"> <font size="3"> Break </td>
         <td style="padding:5px"> <font size="3"> </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 10:30 </td>
+        <td style="padding:5px"> <font size="3"> 10:15 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Conda tutorial <br></td>
         <td style="padding:5px"> <font size="3"> JS, EP, LM, TL </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 11:00 </td>
+        <td style="padding:5px"> <font size="3"> 10:45 </td>
         <td style="padding:5px"> <font size="3"> Wrap up: Conda tutorial </td>
         <td style="padding:5px"> <font size="3"> JS </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 11:15 </td>
+        <td style="padding:5px"> <font size="3"> 11:00 </td>
         <td style="padding:5px"> <font size="3"> Organize your analysis using workflow managers
              <font size="2"> <i><br>
              - Introduction to Snakemake <br>
@@ -114,6 +114,16 @@
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 14:30 </td>
+        <td style="padding:5px"> <font size="3"> Break </td>
+        <td style="padding:5px"> <font size="3"> </td>
+    </tr>
+    <tr>
+        <td style="padding:5px"> <font size="3"> 14:45 </td>
+        <td style="padding:5px"> <font size="3"> ... continued: Snakemake tutorial </td>
+        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+    </tr>
+    <tr>
+        <td style="padding:5px"> <font size="3"> 15:30 </td>
         <td style="padding:5px"> <font size="3"> Wrap-up day 2 </td>
         <td style="padding:5px"> <font size="3"> JS </td>
     </tr>
@@ -134,21 +144,17 @@
         <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 10:15 </td>
-        <td style="padding:5px"> <font size="3"> Break </td>
-        <td style="padding:5px"> <font size="3"> </td>
-    </tr>
-    <tr>
-        <td style="padding:5px"> <font size="3"> 10:30 </td>
-        <td style="padding:5px"> <font size="3"> ... continued: Snakemake tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
-    <tr>
-        <td style="padding:5px"> <font size="3"> 11:00 </td>
+        <td style="padding:5px"> <font size="3"> 09:45 </td>
         <td style="padding:5px"> <font size="3"> Wrap-up: Snakemake tutorial </td>
         <td style="padding:5px"> <font size="3"> JS </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 11:15 </td>
+        <td style="padding:5px"> <font size="3"> 10:00 </td>
+        <td style="padding:5px"> <font size="3"> Break </td>
+        <td style="padding:5px"> <font size="3"> </td>
+    </tr>
+    <tr>
+        <td style="padding:5px"> <font size="3"> 10:15 </td>
         <td style="padding:5px"> <font size="3"> Organize your analysis using workflow managers
              <font size="2"><i><br>
              - Introduction to Nextflow <br>
@@ -156,7 +162,6 @@
         </td>
         <td style="padding:5px"> <font size="3"> EF </td>
     </tr>
-    <tr>
         <td style="padding:5px"> <font size="3"> 12:00 </td>
         <td style="padding:5px"> <font size="3"> Lunch </td>
         <td style="padding:5px"> <font size="3"> </td>
@@ -167,7 +172,17 @@
         <td style="padding:5px"> <font size="3"> JS, JW, LM, TL, EF </td>
     <tr>
     <tr>
+        <td style="padding:5px"> <font size="3"> 14:15 </td>
+        <td style="padding:5px"> <font size="3"> Break </td>
+        <td style="padding:5px"> <font size="3"> </td>
+    </tr>
+    <tr>
         <td style="padding:5px"> <font size="3"> 14:30 </td>
+        <td style="padding:5px"> <font size="3"> ... continued: Nextflow tutorial </td>
+        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL, EF </td>
+    <tr>
+    <tr>
+        <td style="padding:5px"> <font size="3"> 15:30 </td>
         <td style="padding:5px"> <font size="3"> Wrap-up day 3 </td>
         <td style="padding:5px"> <font size="3"> EF </td>
     </tr>
@@ -184,21 +199,6 @@
     </thead>
     <tr>
         <td style="padding:5px"> <font size="3"> 09:00 </td>
-        <td style="padding:5px"> <font size="3"> ... continued: Nextflow tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL, EF </td>
-    <tr>
-    <tr>
-        <td style="padding:5px"> <font size="3"> 10:00 </td>
-        <td style="padding:5px"> <font size="3"> Wrap-up: Nextflow tutorial </td>
-        <td style="padding:5px"> <font size="3"> EF </td>
-    <tr>
-    <tr>
-        <td style="padding:5px"> <font size="3"> 10:15 </td>
-        <td style="padding:5px"> <font size="3"> Break </td>
-        <td style="padding:5px"> <font size="3"> </td>
-    </tr>
-    <tr>
-        <td style="padding:5px"> <font size="3"> 10:30 </td>
         <td style="padding:5px"> <font size="3"> Computational notebooks and reproducible reports
              <font size="2"><i><br>
              - Introduction to R Markdown<br>
@@ -207,12 +207,12 @@
         <td style="padding:5px"> <font size="3"> JS </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 12:00 </td>
-        <td style="padding:5px"> <font size="3"> Lunch </td>
+        <td style="padding:5px"> <font size="3"> 10:30 </td>
+        <td style="padding:5px"> <font size="3"> Break </td>
         <td style="padding:5px"> <font size="3"> </td>
     </tr>
     <tr>
-        <td style="padding:5px"> <font size="3"> 13:00 </td>
+        <td style="padding:5px"> <font size="3"> 10:45 </td>
         <td style="padding:5px"> <font size="3"> Computational notebooks and reproducible reports
              <font size="2"><i><br>
              - Introduction to Jypyter <br>
@@ -220,6 +220,20 @@
         </td>
         <td style="padding:5px"> <font size="3"> JS </td>
     </tr>
+    <tr>
+        <td style="padding:5px"> <font size="3"> 12:15 </td>
+        <td style="padding:5px"> <font size="3"> Lunch </td>
+        <td style="padding:5px"> <font size="3"> </td>
+    </tr>
+    <tr>
+        <td style="padding:5px"> <font size="3"> 13:15 </td>
+        <td style="padding:5px"> <font size="3"> Containerization
+             <font size="2"><i><br>
+             - Introduction to containers <br>
+             - Practical tutorial: Containers <br>
+        </td>
+        <td style="padding:5px"> <font size="3"> JS </td>
+    <tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 14:30  </td>
         <td style="padding:5px"> <font size="3"> Wrap-up day 4 </td>
@@ -238,13 +252,9 @@
     </thead>
     <tr>
         <td style="padding:5px"> <font size="3"> 09:00 </td>
-        <td style="padding:5px"> <font size="3"> Containerization
-             <font size="2"><i><br>
-             - Introduction to containers <br>
-             - Practical tutorial: Containers <br>
-        </td>
-        <td style="padding:5px"> <font size="3"> JS </td>
-    <tr>
+        <td style="padding:5px"> <font size="3"> ... continued: Containers </td>
+        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+    </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 10:30 </td>
         <td style="padding:5px"> <font size="3"> Break </td>

--- a/pages/course-information/schedule.md
+++ b/pages/course-information/schedule.md
@@ -10,7 +10,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 09:00 </td>
         <td style="padding:5px"> <font size="3"> Setting up </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> EF, JS, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 10:00 </td>
@@ -30,7 +30,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 11:15 </td>
         <td style="padding:5px"> <font size="3"> Break-out rooms and ice breaker session </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> EF, JS, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 11:30 </td>
@@ -39,7 +39,7 @@
                - Introduction to version control and Git <br>
                - Practical tutorial: Git <br>
         </td>
-        <td style="padding:5px"> <font size="3"> JS </td>
+        <td style="padding:5px"> <font size="3"> EF </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 12:00 </td>
@@ -54,7 +54,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 14:30 </td>
         <td style="padding:5px"> <font size="3"> Wrap-up day 1 </td>
-        <td style="padding:5px"> <font size="3"> JS </td>
+        <td style="padding:5px"> <font size="3"> EF </td>
     </tr>
 </table>
 
@@ -85,7 +85,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 10:15 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Conda tutorial <br></td>
-        <td style="padding:5px"> <font size="3"> JS, EP, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> JS, EF, EP, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 10:45 </td>
@@ -110,7 +110,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 13:00 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Snakemake tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> JS, EF, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 14:30 </td>
@@ -120,7 +120,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 14:45 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Snakemake tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> JS, EF, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 15:30 </td>
@@ -141,7 +141,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 09:00 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Snakemake tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> JS, EF, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 09:45 </td>
@@ -169,7 +169,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 13:00 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Nextflow tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL, EF </td>
+        <td style="padding:5px"> <font size="3"> EF, JS, JW, LM, TL, EF </td>
     <tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 14:15 </td>
@@ -179,7 +179,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 14:30 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Nextflow tutorial </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL, EF </td>
+        <td style="padding:5px"> <font size="3"> EF, JS, JW, LM, TL, EF </td>
     <tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 15:30 </td>
@@ -204,7 +204,7 @@
              - Introduction to R Markdown<br>
              - Practical tutorial: R Markdown </i>
         </td>
-        <td style="padding:5px"> <font size="3"> JS </td>
+        <td style="padding:5px"> <font size="3"> EF </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 10:30 </td>
@@ -253,7 +253,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 09:00 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Containers </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> JS, EF, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 10:30 </td>
@@ -263,7 +263,7 @@
     <tr>
         <td style="padding:5px"> <font size="3"> 10:45 </td>
         <td style="padding:5px"> <font size="3"> ... continued: Containers </td>
-        <td style="padding:5px"> <font size="3"> JS, JW, LM, TL </td>
+        <td style="padding:5px"> <font size="3"> JS, EF, JW, LM, TL </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 12:15 </td>
@@ -277,7 +277,7 @@
              - How to put all the tools and procedures together <br>
              - How to implement these procedures on a day-to-day basis <br>
         </td>
-        <td style="padding:5px"> <font size="3"> JS </td>
+        <td style="padding:5px"> <font size="3"> EF </td>
     </tr>
     <tr>
         <td style="padding:5px"> <font size="3"> 14:30 </td>


### PR DESCRIPTION
Proposed new schedule for VT23 course round. Nextflow and Container time is increased by 45 minutes each, while Conda is decreased by 15 minutes (I didn't figure out a way to get a nice schedule without doing this, and I think Conda can handle it). Day 2 and 3 are a bit longer, going until 15:30 respectively - wrap-ups start at 15:30 rather than 14:30 as for the other days. Also changed lectures so that we have 5 each.