### PR TITLE
Move Markdown material into a separate page

### DIFF
--- a/pages/conda/conda-1-introduction.md
+++ b/pages/conda/conda-1-introduction.md
@@ -3,7 +3,7 @@ to install a wide range of software and tools using one simple command: `conda
 install`. As an environment manager it allows you to create and manage multiple
 different environments, each with their own set of packages. 
 
-> **Mamba vs Conda**
+> **Mamba vs Conda** <br>
 > As explained in the [pre-course-setup](pre-course-setup) we advocate 
 > using Mamba instead of Conda. Mamba is a faster reimplementation of Conda and
 > can often solve environments where Conda fails to do the job. On the 

--- a/pages/course-information/markdown.md
+++ b/pages/course-information/markdown.md
@@ -1,0 +1,46 @@
+A *markup language* is a system for annotating text documents in order to *e.g.*
+define formatting. HTML, if you are familiar with that, is an example of a
+markup language. HTML uses tags, such as:
+
+```html
+<h1> Heading </h1>
+<h2> Sub-heading </h2>
+<a href="www.webpage.com"> Link </a>
+<ul>
+  <li> List-item1 </li>
+  <li> List-item2 </li>
+  <li> List-item3 </li>
+</ul>
+```
+
+*Markdown* is a lightweight markup language which uses plain-text syntax in
+order to be as unobtrusive as possible, so that a human can easily read it. Look
+at the following toy example:
+
+```markdown
+# Heading
+
+A [link](http://example.com).
+
+## Sub-heading
+
+Text attributes _italic_, *italic*, **bold**, `monospace`.
+
+### Another deeper heading
+
+Bullet list:
+
+  * apples
+  * oranges
+  * pears
+```
+
+A markdown document can be converted to other formats, such as HTML or PDF, for
+viewing in a browser or a PDF reader; in fact, the page you are reading right
+now is written in markdown. Markdown is somewhat ill-defined, and as a
+consequence of that there exist many implementations and extensions. They share
+most of the syntax, however, with various additions on top.
+
+There are a lot more things you can do with markdown than what we show here.
+Indeed, this entire course is mostly written in markdown! You can read more
+about markdown [here](https://www.markdownguide.org/getting-started/).

--- a/pages/git/git-7-working-remotely.md
+++ b/pages/git/git-7-working-remotely.md
@@ -140,6 +140,10 @@ You can find the latest stable version of the Git tutorial for the course
 [here](https://uppsala.instructure.com/courses/73110/pages/git-1-introduction?module_item_id=367079).
 ```
 
+> **The markdown format** <br>
+> If you haven't seen this format before you can learn more about it at the
+> [markdown](markdown) page.
+
 * Add, commit and push these changes to GitHub.
 
 ```bash
@@ -148,28 +152,16 @@ git commit -m "Add README.md"
 git push origin main
 ```
 
-You should now be able to see the rendered markdown document, which looks a bit
-different from the text you copied in from above. Note that there are two
-different header levels, which come from the number of hash signs (`#`) used.
-You can also see bold text (which was surrounded by two asterisks), italic
-text (surrounded by one asterisk), in-line code (surrounded by acute accents)
-and a link (link text inside square brackets followed by link address inside
-parentheses).
-
-It is important to add README-files to your repositories so that they are better
-documented and more easily understood by others and, more likely, your future self.
-In fact, documentation is an important part of reproducible research! While the
-tools that you are introduced to by this course are all directly related to
-making science reproducible, you will *also* need good documentation. Make it
-a habit of always adding README-files for your repositories, fully explaining
-the ideas and rationale behind the project. You can even add README-files to
-sub-directories as well, giving you the opportunity to go more in-depth where
-you so desire.
-
-> **Tip** <br>
-> There are a lot more things you can do with markdown than what we show here.
-> Indeed, this entire course is mostly written in markdown! You can read
-> more about markdown [here](https://www.markdownguide.org/getting-started/).
+You should now be able to see the rendered markdown document in your GitHub
+repository. It is important to add README-files to your repositories so that
+they are better documented and more easily understood by others and, more
+likely, your future self. In fact, documentation is an important part of
+reproducible research! While the tools that you are introduced to by this course
+are all directly related to making science reproducible, you will *also* need
+good documentation. Make it a habit of always adding README-files for your
+repositories, fully explaining the ideas and rationale behind the project. You
+can even add README-files to sub-directories as well, giving you the opportunity
+to go more in-depth where you so desire.
 
 > **Quick recap** <br>
 > We learned how to connect local Git repositories to remote locations such as

--- a/pages/rmarkdown/r-markdown-1-introduction.md
+++ b/pages/rmarkdown/r-markdown-1-introduction.md
@@ -1,56 +1,15 @@
-A *markup language* is a system for annotating text documents in order to
-*e.g.* define formatting. HTML, if you are familiar with that, is an example of
-a markup language. HTML uses tags, such as:
-
-```html
-<h1>Heading</h1>
-<h2>Sub-heading</h2>
-<a href="www.webpage.com">Link</a>
-<ul>
-  <li>List-item1</li>
-  <li>List-item2</li>
-  <li>List-item3</li>
-</ul>
-```
-
-*Markdown* is a lightweight markup language which uses plain-text syntax in
-order to be as unobtrusive as possible, so that a human can easily read it.
-Some examples:
-
-```no-highlight
-# Heading
-
-## Sub-heading
-
-### Another deeper heading
-
-A [link](http://example.com).
-
-Text attributes _italic_, *italic*, **bold**, `monospace`.
-
-Bullet list:
-
-  * apples
-  * oranges
-  * pears
-```
-
-A markdown document can be converted to other formats, such as HTML or PDF, for
-viewing in a browser or a PDF reader; the page you are reading right now is
-written in markdown. Markdown is somewhat ill-defined, and as a consequence of
-that there exist many implementations and extensions, although they share most
-of the syntax. *R Markdown* is one such implementation/extension.
-
-R Markdown documents can be used both to save and execute code and to generate
-reports in various formats. This is done by mixing markdown (as in the example
-above), and so-called code chunks in the same document. The code itself, as
-well as the output it generates, can be included in the final report.
+The *R Markdown* format (usually `.rmd` or `.Rmd`) is a multi-functional format,
+especially for scientific coding and analyses. R Markdown documents can be used
+both to save and execute code as well as generating reports in various output
+formats. This is done by mixing *markdown* and so-called *code chunks* in the
+same document; we also have [course materials for markdown](markdown). The code
+itself, as well as the output it generates, can be included in the final report.
 
 R Markdown makes your analysis more reproducible by connecting your code,
 figures and descriptive text. You can use it to make reproducible reports,
 rather than *e.g.* copy-pasting figures into a Word document. You can also use
 it as a notebook, in the same way as lab notebooks are used in a wet lab
-setting (or as we utilise Jupyter notebooks in the tutorial after this one).
+setting (or as we utilise *Jupyter notebooks* in the tutorial after this one).
 
 This tutorial depends on files from the course GitHub repo. Take a look at the
 [setup](pre-course-setup) for instructions on how to set it up if you haven't

--- a/pages/rmarkdown/r-markdown-2-the-basics.md
+++ b/pages/rmarkdown/r-markdown-2-the-basics.md
@@ -31,50 +31,36 @@ in an R Markdown document:
 2. Code chunks (written in R or another [supported language](https://bookdown.org/yihui/rmarkdown/language-engines.html))
 3. The YAML header
 
-Let's dig deeper into each of these in the following sections! But first, just
+We will dig deeper into each of these in the following sections! But first, just
 to get the flavor for things to come: press the little *Knit*-button located at
 the top of the text editor panel in RStudio. This will prompt you to save the
-Rmd file (do that), and generate the output file (an HTML file in this case).
+`rmd` file (do that), and generate the output file (an HTML file in this case).
 It will also open up a preview of this file for you.
 
-Some commonly used formatting written in markdown is shown below, which you may
-recognize from the [Git tutorial](git-7-working-remotely):
+In addition to the basic [markdown functionality](markdown), R Markdown also has
+some useful code-specific additions:
 
-```no-highlight
-# This is a heading
-
-This is a paragraph.
-This line-break will not appear in the output file.\
-But this will (since the previous line ends with a backslash).
-
-This is a new paragraph.
-
-## This is a sub-heading
-
-This is **bold text**, this is *italic text*, this is `monospaced text`,
-and this is [a link](http://rmarkdown.rstudio.com/lesson-1.html).
-
+```rmd
 An important feature of R Markdown is that you are allowed to use R code
 inline to generate text by enclosing it with `r `. As an example: 112/67 is
 equal to `r round(112/67, 2)`. You can also use multiple commands like this:
 I like `r fruits <- c("apples","bananas"); paste(fruits, collapse = " and ")`!
 ```
 
-The above markdown would generate something like this:
-
-> ![](images/markdown_example.png){ width=600px }
-
-Instead of reiterating information here, take a look on the first page (only
-the first page!) of this [reference]( https://www.rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf).
-This will show you how to write more stuff in markdown and how it will be
-displayed once the markdown document is converted to an output file (*e.g.*
-HTML or PDF). An even more complete guide is available
+Any in-line code starting with "r " (note the space) will be evaluated as R code
+- this works for the other supported languages as well Instead of reiterating
+lots of information here, take a look on the first page (only the first page!)
+of this [reference](https://www.rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf).
+This will show you how to write more stuff in R Markdown and how it will be
+displayed once the document is converted to an output file (*e.g.* HTML or PDF).
+An even more complete guide is available
 [here](http://rmarkdown.rstudio.com/authoring_pandoc_markdown.html).
 
-* Try out some of the markdown described above (and in the links) in your
-  template R Markdown document! Press *Knit* to see the effect of your changes.
-  Don't worry about the code chunks just yet, we'll come to that in a second.
+* Try out some basic markdown in your template R Markdown document!
+
+* Press *Knit* to see the effect of your changes. Don't worry about the code
+  chunks just yet, we'll come to that in a second.
 
 > **Quick recap** <br>
-> In this section you learned and tried out some of the basic markdown
-> syntax.
+> In this section you learned how to create, edit and render basic R Markdown
+> documents, as well as how to write in-line code.

--- a/pages/rmarkdown/r-markdown-3-code-chunks.md
+++ b/pages/rmarkdown/r-markdown-3-code-chunks.md
@@ -1,6 +1,5 @@
-Enough about markdown, let's get to the fun part and include some code! Look at
-the last code chunk in the template R Markdown document that you just created,
-as an example:
+It's time to include some code! Look at the last code chunk in the template R
+Markdown document that you just created, as an example:
 
 ````
 ```{r pressure, echo = FALSE}


### PR DESCRIPTION
This moves the scattered Markdown material into one single place and leaves links in the previous locations, for a more collected and easier-to-reference example material.