### PR TITLE
Update gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,20 +11,28 @@
 image: nfcore/gitpod:latest
 
 tasks:
-  - name: Install Pixi
+  - name: Init Conda and Install Pixi
     command: |
       sudo chown gitpod -R /home/gitpod/
+      # Conda setup
+      export CONDA_ENVS_PATH=/workspace/conda/envs
+      conda config --set repodata_threads 4
+      conda config --set auto_activate_base false
+      conda config --remove channels defaults
+      conda init
+      conda env create -f tutorials/jupyter/environment.yml
+      conda env create -f tutorials/nextflow/environment.yml
+      conda env create -f tutorials/quarto/environment.yml
+      conda env create -f tutorials/snakemake/environment.yml
+      # Install Pixi
       curl -fsSL https://pixi.sh/install.sh | bash
       . /home/gitpod/.bashrc
+      echo sourced /home/gitpod/.bashrc
+      conda env list
   - name: Update Nextflow
     command: |
       nextflow self-update
       exit
-  - name: Install Snakemake and Quarto
-    command: |
-      conda install snakemake quarto -y
-      exit
-
 
 vscode:
   extensions:

--- a/tutorials/quarto/environment.yml
+++ b/tutorials/quarto/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - quarto
   - jupyter
   - python=3
   - r-base


### PR DESCRIPTION
Changes Gitpod environment to work more similarly to what they use in the course.
- Sets up conda to use multiple threads for download
- Sets conda to store environments in /workspace ( work in /workspace is saved when a gitpod shuts down and is restarted, but the init script is run again ). I need to confirm if this actually helps.
- Removes defaults channel
- Doesn't autoactivate base env
- Autoinstalls environments

- Adds Quarto to quarto-env