### PR TITLE
Update curl command

### DIFF
--- a/tutorials/conda/code/run_qc.sh
+++ b/tutorials/conda/code/run_qc.sh
@@ -8,9 +8,9 @@ SRR935091="https://figshare.scilifelab.se/ndownloader/files/39539770"
 SRR935092="https://figshare.scilifelab.se/ndownloader/files/39539773"
 
 # Download fastq files from remote repository and put in data directory
-curl -L  "$SRR935090" -o data/SRR935090.fastq.gz
-curl -L  "$SRR935091" -o data/SRR935091.fastq.gz
-curl -L  "$SRR935092" -o data/SRR935092.fastq.gz
+curl -L -A "Mozilla/5.0" "$SRR935090" -o data/SRR935090.fastq.gz
+curl -L -A "Mozilla/5.0" "$SRR935091" -o data/SRR935091.fastq.gz
+curl -L -A "Mozilla/5.0" "$SRR935092" -o data/SRR935092.fastq.gz
 
 # Run fastqc and output to results directory
 fastqc  data/SRR935090.fastq.gz --outdir=results/fastqc/


### PR DESCRIPTION
This PR adds a user agent (`-A`, `--user-agent`) to the curl command in order to allow downloads from figshare.