### PR TITLE
Jupyter updates

### DIFF
--- a/env/conda-specfiles/jupyter-env_linux-64_conda_spec.txt
+++ b/env/conda-specfiles/jupyter-env_linux-64_conda_spec.txt
@@ -130,6 +130,7 @@ https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda#04
 https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda#12c566707c80111f9799308d9e265aef
 https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda#cf45f4278afd6f4e6d03eda0f435d527
 https://conda.anaconda.org/conda-forge/linux-64/rpy2-3.6.4-py314r45hb5023e3_1.conda#6aa57c568bec16fcdd694b209ed365e2
+https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda#09a970fbf75e8ed1aa633827ded6aa4f
 https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda#962b9857ee8e7018c22f2776ffa0b2d7
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda#9efbfdc37242619130ea42b1cc4ed861
 https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.2-pyhd8ed1ab_0.conda#5d99943f2ae3cc69e1ada12ce9d4d701

--- a/env/conda-specfiles/jupyter-env_osx-64_conda_spec.txt
+++ b/env/conda-specfiles/jupyter-env_osx-64_conda_spec.txt
@@ -145,6 +145,7 @@ https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda#04
 https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda#12c566707c80111f9799308d9e265aef
 https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py314h8ca4d5a_1.conda#71c2caaa13f50fe0ebad0f961aee8073
 https://conda.anaconda.org/conda-forge/osx-64/rpy2-3.6.4-py314r45h4b00e77_1.conda#4dac0fb2c1e8912d3b0326d0731c478d
+https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda#09a970fbf75e8ed1aa633827ded6aa4f
 https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda#962b9857ee8e7018c22f2776ffa0b2d7
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda#9efbfdc37242619130ea42b1cc4ed861
 https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.2-pyhd8ed1ab_0.conda#5d99943f2ae3cc69e1ada12ce9d4d701

--- a/env/conda-specfiles/jupyter-env_osx-arm64_conda_spec.txt
+++ b/env/conda-specfiles/jupyter-env_osx-arm64_conda_spec.txt
@@ -145,6 +145,7 @@ https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda#04
 https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda#12c566707c80111f9799308d9e265aef
 https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py314h44086f9_1.conda#10dd19e4c797b8f8bdb1ec1fbb6821d7
 https://conda.anaconda.org/conda-forge/osx-arm64/rpy2-3.6.4-py314r45h77b1809_1.conda#9d813e559dd7d4e1f1061ba8bd8d4181
+https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda#09a970fbf75e8ed1aa633827ded6aa4f
 https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda#962b9857ee8e7018c22f2776ffa0b2d7
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda#9efbfdc37242619130ea42b1cc4ed861
 https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.2-pyhd8ed1ab_0.conda#5d99943f2ae3cc69e1ada12ce9d4d701

--- a/pages/jupyter.qmd
+++ b/pages/jupyter.qmd
@@ -454,7 +454,7 @@ with error bars representing a 95% confidence interval.
 Let's say that instead we want to plot the mean value of the body mass of the
 penguins at the different islands where they were examined.
 
-```
+```python
 sns.barplot(data=penguins, x="island", y="body_mass_g", errorbar="sd")
 ```
 
@@ -553,10 +553,11 @@ it:
 
 ```python
 interactive_scatterplot = interactive(scatterplot,
-            x=["bill_length_mm","bill_depth_mm","flipper_length_mm","body_mass_g"],
-            y=["body_mass_g","bill_length_mm","bill_depth_mm","flipper_length_mm"],
-            hue=["species","island","sex"],
-            palette=["Set1","Set2","Dark2","Paired"])
+    x=["bill_length_mm","bill_depth_mm","flipper_length_mm","body_mass_g"],
+    y=["body_mass_g","bill_length_mm","bill_depth_mm","flipper_length_mm"],
+    hue=["species","island","sex"],
+    palette=["Set1","Set2","Dark2","Paired"]
+)
 ```
 
 Importantly, all parameters defined in the `scatterplot` function must be given
@@ -602,11 +603,12 @@ call the `interactive` function so that it looks like this, then run it:
 
 ```python
 interactive_scatterplot = interactive(scatterplot,
-            x=["bill_length_mm","bill_depth_mm","flipper_length_mm","body_mass_g"],
-            y=["body_mass_g","bill_length_mm","bill_depth_mm","flipper_length_mm",],
-            hue=["species","island","sex"],
-            palette=["Set1","Set2","Dark2","Paired"],
-            size=(20,100,10))
+    x=["bill_length_mm","bill_depth_mm","flipper_length_mm","body_mass_g"],
+    y=["body_mass_g","bill_length_mm","bill_depth_mm","flipper_length_mm",],
+    hue=["species","island","sex"],
+    palette=["Set1","Set2","Dark2","Paired"],
+    size=(20,100,10)
+)
 ```
 
 Here the `size` argument is defined as a
@@ -675,7 +677,7 @@ plot should now have a title and you should see a new color picker below the
 slider for the point size. Try changing the title colour by clicking on the new
 color picker.
 
-::: {.callout-caution}
+::: {.callout-note}
 Note that you may have to close the colour picker once you've made your
 choice in order to make the plot update.
 :::

--- a/pages/jupyter.qmd
+++ b/pages/jupyter.qmd
@@ -362,7 +362,7 @@ float(100/3)
 
 Next set the precision to 4 decimal points by running a cell with:
 
-```
+```python
 %precision 4
 ```
 
@@ -959,6 +959,21 @@ states'.
 One caveat of `nbval` is that it doesn't work well with cells that generate
 plots. You can tell `nbval` to ignore the output of specific cells by adding
 `# NBVAL_IGNORE_OUTPUT` to the top of a cell.
+:::
+
+::: {.callout-tip title="Marimo - the future of Python notebooks?"}
+
+While Jupyter is a very powerful tool you may have noticed that there things
+that don't play nicely with some core aspects of reproducibility. For example,
+the JSON format used for notebooks is a little heavy for version tracking
+(especially when cell output is included) and potential 'hidden states'
+illustrated above can lead to non-reproducible notebooks.
+[Marimo](https://docs.marimo.io/) is a new tool for Python notebooks that solves
+a lot of these issues by using a pure python format and re-running dependent
+cells when the code is updated. The Marimo project is still relatively new which
+is why we don't currently include it in this course (something we will likely
+change in the future), but feel free to try it out if you like.
+
 :::
 
 ::: {.callout-note title="Quick recap"}

--- a/pixi.lock
+++ b/pixi.lock
@@ -266,6 +266,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.0-py314h8ec4b1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -585,6 +586,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.1.0-py314hf9dbaa9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -884,6 +886,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.0-py314hab283cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -11447,6 +11450,15 @@ packages:
   license: HPND
   size: 995543
   timestamp: 1767353279681
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
+  sha256: 5f66ea31d62188c266c5a8752119b0cc90a5bf05963f665cf48a33e0ec58d39c
+  md5: 09a970fbf75e8ed1aa633827ded6aa4f
+  depends:
+  - python >=3.13.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180743
+  timestamp: 1770270312477
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
   md5: c01af13bdc553d1a8fbfff6e8db075f0

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,6 +33,7 @@ papermill = "*"
 nbval = "*"
 nbdime = "*"
 altair = "*"
+pip = "*"
 
 [feature.nextflow-env]
 channels = ["conda-forge", "bioconda"]


### PR DESCRIPTION
This pull request makes several small but important updates to the Jupyter environment and documentation. The main change is the addition of `pip` to the Conda environment specification files and the `pixi.toml` file, ensuring that Jupyter extensions can be installed from the browser interface. Additionally, there are minor improvements to code formatting and documentation clarity in the Jupyter tutorial.

Dependency updates:

* Added `pip` version 26.0.1 to the Conda environment specification files for Linux, OSX-64, and OSX-arm64 (`jupyter-env_linux-64_conda_spec.txt`, `jupyter-env_osx-64_conda_spec.txt`, `jupyter-env_osx-arm64_conda_spec.txt`) to ensure consistent Python package management across platforms. [[1]](diffhunk://#diff-722123f89975caafa0abf081f5ac3af7aedcc0cc7c0c83214af76f2ef2a005a1R133) [[2]](diffhunk://#diff-20a8522735dda8ba8c3ffd34c4cb9ca8b01dfed9afcf0f3e064845317afec0f9R148) [[3]](diffhunk://#diff-ce8ed89076bfc08d807750a78b4edcf75e1191082c9b0c2bc7e1f8051843d1d1R148)
* Added `pip` to the `pixi.toml` dependencies, aligning the Pixi environment with the Conda spec files.

Documentation and code formatting improvements:

* Updated code blocks in `pages/jupyter.qmd` to specify `python` for syntax highlighting and corrected function argument formatting for clarity. [[1]](diffhunk://#diff-9ca72efdc4d398488fbc4e432a6569dc2534575028eaf09b753cd7a3d7e9f7beL365-R365) [[2]](diffhunk://#diff-9ca72efdc4d398488fbc4e432a6569dc2534575028eaf09b753cd7a3d7e9f7beL457-R457) [[3]](diffhunk://#diff-9ca72efdc4d398488fbc4e432a6569dc2534575028eaf09b753cd7a3d7e9f7beL559-R560) [[4]](diffhunk://#diff-9ca72efdc4d398488fbc4e432a6569dc2534575028eaf09b753cd7a3d7e9f7beL609-R611)
* Changed a callout from "caution" to "note" for improved tone and accuracy in the Jupyter tutorial.
* Added a new tip callout introducing Marimo as a potential future alternative to Jupyter notebooks, highlighting its advantages for reproducibility and version control.